### PR TITLE
[feature] 스토리지를 사용하여 미션 정보 저장. 미션 기능 구현

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '12.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,23 @@
+PODS:
+  - Flutter (1.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+
+SPEC CHECKSUMS:
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+
+PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
+
+COCOAPODS: 1.15.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		C74BD9B2B5DC465BD79A877A /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ADAAA655E145AB3BCF08096 /* Pods_Runner.framework */; };
+		EE5E17FCE4B9AB53D84E8EC2 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8060E8E7DBF6BC82D97E61E4 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,14 +42,19 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		00A1421A8622211177B6173F /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		2ADAAA655E145AB3BCF08096 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		3DE174CA5D355B86E04EB36E /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		67663AB51234477E42E29318 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		8060E8E7DBF6BC82D97E61E4 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,13 +62,25 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A3DBE5BB2899C7E7DF8587FD /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		AF6EEB00612D736EF5487D0E /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		F1BD539773721FFD1C81F341 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		8A6C9B6BF1C9FA279CB61A81 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EE5E17FCE4B9AB53D84E8EC2 /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C74BD9B2B5DC465BD79A877A /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,6 +113,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				DE6C460A3A6F7B41FA8B1C18 /* Pods */,
+				C6A933A8E4E0C19EB68AE431 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -121,6 +142,29 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		C6A933A8E4E0C19EB68AE431 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2ADAAA655E145AB3BCF08096 /* Pods_Runner.framework */,
+				8060E8E7DBF6BC82D97E61E4 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		DE6C460A3A6F7B41FA8B1C18 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				AF6EEB00612D736EF5487D0E /* Pods-Runner.debug.xcconfig */,
+				67663AB51234477E42E29318 /* Pods-Runner.release.xcconfig */,
+				A3DBE5BB2899C7E7DF8587FD /* Pods-Runner.profile.xcconfig */,
+				F1BD539773721FFD1C81F341 /* Pods-RunnerTests.debug.xcconfig */,
+				00A1421A8622211177B6173F /* Pods-RunnerTests.release.xcconfig */,
+				3DE174CA5D355B86E04EB36E /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -128,8 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				E2ABDA6CBE9A31917DE8955C /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				8A6C9B6BF1C9FA279CB61A81 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,12 +191,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				C0A0CAF4BBB98E0BB9F53444 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				B78EDD397056EF5B677222BF /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -252,6 +300,67 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		B78EDD397056EF5B677222BF /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C0A0CAF4BBB98E0BB9F53444 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E2ABDA6CBE9A31917DE8955C /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -378,6 +487,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F1BD539773721FFD1C81F341 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -395,6 +505,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 00A1421A8622211177B6173F /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -410,6 +521,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DE174CA5D355B86E04EB36E /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,8 +7,11 @@ import 'screens/login_page.dart';
 import 'screens/signup_page.dart';
 import 'screens/config_page.dart';
 import 'screens/history_page.dart';
+import 'services/mission_service.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized(); // Flutter 바인딩 초기화
+  await MissionService.init(); // MissionService 초기화
   runApp(const MyApp());
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'services/mission_service.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized(); // Flutter 바인딩 초기화
   await MissionService.init(); // MissionService 초기화
+  MissionService.debugStorageContent(); // 디버깅용 스토리지 상태 출력
   runApp(const MyApp());
 }
 

--- a/lib/models/mission.dart
+++ b/lib/models/mission.dart
@@ -1,0 +1,50 @@
+class Mission {
+  final String id;
+  final String time;
+  final bool isCompleted;
+  final DateTime? completedAt;
+  final DateTime date;
+
+  Mission({
+    required this.id,
+    required this.time,
+    required this.isCompleted,
+    this.completedAt,
+    required this.date,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'time': time,
+        'isCompleted': isCompleted,
+        'completedAt': completedAt?.toIso8601String(),
+        'date': date.toIso8601String(),
+      };
+
+  factory Mission.fromJson(Map<String, dynamic> json) => Mission(
+        id: json['id'],
+        time: json['time'],
+        isCompleted: json['isCompleted'],
+        completedAt: json['completedAt'] != null
+            ? DateTime.parse(json['completedAt'])
+            : null,
+        date: DateTime.parse(json['date']),
+      );
+
+  bool get expired {
+    if (isCompleted) return false;
+    final now = DateTime.now();
+    return DateTime(
+      date.year,
+      date.month,
+      date.day,
+      int.parse(time.split(':')[0]),
+      int.parse(time.split(':')[1]),
+    ).isBefore(now);
+  }
+
+  String? get formattedCompletedTime {
+    if (completedAt == null) return null;
+    return '${completedAt!.hour.toString().padLeft(2, '0')}:${completedAt!.minute.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/screens/config_page.dart
+++ b/lib/screens/config_page.dart
@@ -64,9 +64,6 @@ class _ConfigPageState extends State<ConfigPage> {
     } else {
       await MissionService.saveMissionTime(2, null);
     }
-
-    // 저장된 데이터 확인
-    MissionService.debugMissionData();
   }
 
   Future<void> _selectTime(BuildContext context, bool isFirstMission) async {

--- a/lib/screens/config_page.dart
+++ b/lib/screens/config_page.dart
@@ -26,6 +26,9 @@ class _ConfigPageState extends State<ConfigPage> {
     final mission1String = MissionService.getMissionTime(1);
     final mission2String = MissionService.getMissionTime(2);
 
+    print('저장된 미션1 시간: $mission1String');
+    print('저장된 미션2 시간: $mission2String');
+
     setState(() {
       if (mission1String != null) {
         final parts = mission1String.split(':');
@@ -67,9 +70,13 @@ class _ConfigPageState extends State<ConfigPage> {
   }
 
   Future<void> _selectTime(BuildContext context, bool isFirstMission) async {
+    final initialTime = isFirstMission
+        ? _mission1Time ?? TimeOfDay.now()
+        : _mission2Time ?? TimeOfDay.now();
+
     final TimeOfDay? picked = await showTimePicker(
       context: context,
-      initialTime: TimeOfDay.now(),
+      initialTime: initialTime,
     );
 
     if (picked != null) {

--- a/lib/screens/config_page.dart
+++ b/lib/screens/config_page.dart
@@ -2,10 +2,46 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'home_page.dart';
 
-class ConfigPage extends StatelessWidget {
+class ConfigPage extends StatefulWidget {
   const ConfigPage({super.key});
 
   static const String routeName = '/config';
+
+  @override
+  State<ConfigPage> createState() => _ConfigPageState();
+}
+
+class _ConfigPageState extends State<ConfigPage> {
+  TimeOfDay? _mission1Time;
+  TimeOfDay? _mission2Time;
+
+  Future<void> _selectTime(BuildContext context, bool isFirstMission) async {
+    final TimeOfDay? picked = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.now(),
+    );
+
+    if (picked != null) {
+      setState(() {
+        if (isFirstMission) {
+          _mission1Time = picked;
+        } else {
+          _mission2Time = picked;
+        }
+      });
+      print('선택된 시간: ${picked.format(context)}');
+    }
+  }
+
+  void _resetTime(bool isFirstMission) {
+    setState(() {
+      if (isFirstMission) {
+        _mission1Time = null;
+      } else {
+        _mission2Time = null;
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -15,15 +51,44 @@ class ConfigPage extends StatelessWidget {
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: [
-            const TextField(
-              decoration: InputDecoration(
-                labelText: '미션시간 입력',
+            ListTile(
+              title: const Text('미션시간 1'),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextButton(
+                    onPressed: () => _selectTime(context, true),
+                    child: Text(
+                      _mission1Time?.format(context) ?? '시간 선택',
+                      style: const TextStyle(fontSize: 16),
+                    ),
+                  ),
+                  if (_mission1Time != null)
+                    IconButton(
+                      icon: const Icon(Icons.clear),
+                      onPressed: () => _resetTime(true),
+                    ),
+                ],
               ),
             ),
-            const SizedBox(height: 20),
-            const TextField(
-              decoration: InputDecoration(
-                labelText: '미션시간2 입력',
+            ListTile(
+              title: const Text('미션시간 2'),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextButton(
+                    onPressed: () => _selectTime(context, false),
+                    child: Text(
+                      _mission2Time?.format(context) ?? '시간 선택',
+                      style: const TextStyle(fontSize: 16),
+                    ),
+                  ),
+                  if (_mission2Time != null)
+                    IconButton(
+                      icon: const Icon(Icons.clear),
+                      onPressed: () => _resetTime(false),
+                    ),
+                ],
               ),
             ),
             const SizedBox(height: 20),
@@ -35,9 +100,11 @@ class ConfigPage extends StatelessWidget {
             ),
             const SizedBox(height: 20),
             ElevatedButton(
-              onPressed: () {
-                context.go(HomePage.routeName);
-              },
+              onPressed: _mission1Time != null || _mission2Time != null
+                  ? () {
+                      context.go(HomePage.routeName);
+                    }
+                  : null, // 최소 하나의 시간이 선택되어야 버튼 활성화
               child: const Text('설정 완료'),
             ),
           ],

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -17,18 +17,65 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   String? mission1Time;
   String? mission2Time;
+  bool mission1Completed = false;
+  bool mission2Completed = false;
+  bool mission1Expired = false;
+  bool mission2Expired = false;
+  String? mission1CompletedAt;
+  String? mission2CompletedAt;
 
   @override
   void initState() {
     super.initState();
     _loadMissionTimes();
+    _checkMissionStatus();
   }
 
   void _loadMissionTimes() {
     setState(() {
       mission1Time = MissionService.getMissionTime(1);
       mission2Time = MissionService.getMissionTime(2);
+      mission1Completed = MissionService.isMissionCompleted(1);
+      mission2Completed = MissionService.isMissionCompleted(2);
+      mission1CompletedAt = MissionService.getMissionCompletedAt(1);
+      mission2CompletedAt = MissionService.getMissionCompletedAt(2);
     });
+  }
+
+  void _checkMissionStatus() {
+    final now = TimeOfDay.now();
+    final currentMinutes = now.hour * 60 + now.minute;
+
+    setState(() {
+      if (mission1Time != null) {
+        final parts = mission1Time!.split(':');
+        final missionMinutes = int.parse(parts[0]) * 60 + int.parse(parts[1]);
+        mission1Expired = currentMinutes > missionMinutes && !mission1Completed;
+        print('mission1Expired: $mission1Expired');
+      }
+
+      if (mission2Time != null) {
+        final parts = mission2Time!.split(':');
+        final missionMinutes = int.parse(parts[0]) * 60 + int.parse(parts[1]);
+        mission2Expired = currentMinutes > missionMinutes && !mission2Completed;
+        print('mission2Expired: $mission2Expired');
+      }
+    });
+  }
+
+  Future<void> _toggleMissionComplete(int missionNumber) async {
+    final newState = await MissionService.toggleMissionComplete(missionNumber);
+    setState(() {
+      if (missionNumber == 1) {
+        mission1Completed = newState;
+      } else {
+        mission2Completed = newState;
+      }
+    });
+
+    // 미션 상태 변경 후 만료 상태와 완료 시간 다시 로드
+    _checkMissionStatus();
+    _loadMissionTimes(); // 완료 시간 업데이트를 위해 추가
   }
 
   @override
@@ -37,22 +84,72 @@ class _HomePageState extends State<HomePage> {
       appBar: AppBar(title: const Text('Home')),
       body: ListView(
         children: [
-          if (mission1Time != null)
+          if (mission1Time != null) ...[
+            if (mission1Expired)
+              Container(
+                color: Colors.red[100],
+                padding: const EdgeInsets.all(16.0),
+                child: const Text(
+                  '⚠️ 미션1이 완료되지 않았습니다!!!',
+                  style: TextStyle(
+                    color: Colors.red,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 16,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
             ListTile(
-              title: Text('미션시간 1 ($mission1Time)'),
+              title: Text(
+                '미션시간 1 ($mission1Time)',
+                style: TextStyle(
+                  color: mission1Expired ? Colors.red : null,
+                ),
+              ),
+              subtitle: mission1Completed && mission1CompletedAt != null
+                  ? Text('완료 시간: $mission1CompletedAt')
+                  : null,
               trailing: Checkbox(
-                value: false,
-                onChanged: null,
+                value: mission1Completed,
+                onChanged: (bool? value) {
+                  _toggleMissionComplete(1);
+                },
               ),
             ),
-          if (mission2Time != null)
+          ],
+          if (mission2Time != null) ...[
+            if (mission2Expired)
+              Container(
+                color: Colors.red[100],
+                padding: const EdgeInsets.all(16.0),
+                child: const Text(
+                  '⚠️ 미션2가 완료되지 않았습니다!!!',
+                  style: TextStyle(
+                    color: Colors.red,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 16,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
             ListTile(
-              title: Text('미션시간 2 ($mission2Time)'),
+              title: Text(
+                '미션시간 2 ($mission2Time)',
+                style: TextStyle(
+                  color: mission2Expired ? Colors.red : null,
+                ),
+              ),
+              subtitle: mission2Completed && mission2CompletedAt != null
+                  ? Text('완료 시간: $mission2CompletedAt')
+                  : null,
               trailing: Checkbox(
-                value: false,
-                onChanged: null,
+                value: mission2Completed,
+                onChanged: (bool? value) {
+                  _toggleMissionComplete(2);
+                },
               ),
             ),
+          ],
           if (mission1Time == null && mission2Time == null)
             const Center(
               child: Padding(

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -3,32 +3,66 @@ import 'package:go_router/go_router.dart';
 import 'config_page.dart';
 import 'history_page.dart';
 import 'login_page.dart';
+import '../services/mission_service.dart';
 
-class HomePage extends StatelessWidget {
+class HomePage extends StatefulWidget {
   const HomePage({super.key});
 
   static const String routeName = '/home';
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  String? mission1Time;
+  String? mission2Time;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMissionTimes();
+  }
+
+  void _loadMissionTimes() {
+    setState(() {
+      mission1Time = MissionService.getMissionTime(1);
+      mission2Time = MissionService.getMissionTime(2);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Home')),
       body: ListView(
-        children: const [
-          ListTile(
-            title: Text('미션시간 1'),
-            trailing: Checkbox(
-              value: false,
-              onChanged: null,
+        children: [
+          if (mission1Time != null)
+            ListTile(
+              title: Text('미션시간 1 ($mission1Time)'),
+              trailing: Checkbox(
+                value: false,
+                onChanged: null,
+              ),
             ),
-          ),
-          ListTile(
-            title: Text('미션시간 2'),
-            trailing: Checkbox(
-              value: false,
-              onChanged: null,
+          if (mission2Time != null)
+            ListTile(
+              title: Text('미션시간 2 ($mission2Time)'),
+              trailing: Checkbox(
+                value: false,
+                onChanged: null,
+              ),
             ),
-          ),
+          if (mission1Time == null && mission2Time == null)
+            const Center(
+              child: Padding(
+                padding: EdgeInsets.all(16.0),
+                child: Text(
+                  '설정된 미션이 없습니다.\n설정 메뉴에서 미션 시간을 설정해주세요.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
         ],
       ),
       bottomNavigationBar: BottomNavigationBar(
@@ -57,7 +91,6 @@ class HomePage extends StatelessWidget {
         onTap: (index) {
           switch (index) {
             case 0:
-              // 이미 홈 페이지에 있으므로 아무 작업도 하지 않음
               break;
             case 1:
               context.go(HistoryPage.routeName);

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -11,7 +11,11 @@ class MissionService {
 
   // SharedPreferences 초기화
   static Future<void> init() async {
+    if (_prefs != null) return; // 이미 초기화되어 있다면 스킵
+
     _prefs = await SharedPreferences.getInstance();
+    print('SharedPreferences 초기화 완료');
+    debugStorageContent(); // 현재 저장된 모든 데이터 출력
   }
 
   // 미션 시간 저장
@@ -119,5 +123,20 @@ class MissionService {
 
     final dateTime = DateTime.parse(dateString);
     return '${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
+  }
+
+  // 저장소의 모든 데이터 출력 (디버깅용)
+  static void debugStorageContent() {
+    if (_prefs == null) {
+      print('SharedPreferences가 초기화되지 않음');
+      return;
+    }
+
+    print('\n=== 저장소 전체 데이터 ===');
+    final keys = _prefs!.getKeys();
+    for (final key in keys) {
+      print('$key: ${_prefs!.get(key)}');
+    }
+    print('=======================\n');
   }
 }

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -1,0 +1,92 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MissionService {
+  static const String _mission1TimeKey = 'mission1_time';
+  static const String _mission2TimeKey = 'mission2_time';
+  static const String _mission1CompletedKey = 'mission1_completed';
+  static const String _mission2CompletedKey = 'mission2_completed';
+  static SharedPreferences? _prefs;
+
+  // SharedPreferences 초기화
+  static Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+  }
+
+  // 미션 시간 저장
+  static Future<void> saveMissionTime(int missionNumber, String? time) async {
+    if (_prefs == null) await init();
+
+    final key = missionNumber == 1 ? _mission1TimeKey : _mission2TimeKey;
+    if (time != null) {
+      await _prefs!.setString(key, time);
+    } else {
+      await _prefs!.remove(key);
+    }
+    print('미션$missionNumber 시간 저장: $time');
+  }
+
+  // 미션 시간 불러오기
+  static String? getMissionTime(int missionNumber) {
+    if (_prefs == null) return null;
+
+    final key = missionNumber == 1 ? _mission1TimeKey : _mission2TimeKey;
+    final time = _prefs!.getString(key);
+    print('미션$missionNumber 시간 불러오기: $time');
+    return time;
+  }
+
+  // 미션 완료 상태 토글
+  static Future<bool> toggleMissionComplete(int missionNumber) async {
+    if (_prefs == null) await init();
+
+    final key =
+        missionNumber == 1 ? _mission1CompletedKey : _mission2CompletedKey;
+    final currentState = _prefs!.getBool(key) ?? false;
+    final newState = !currentState;
+    await _prefs!.setBool(key, newState);
+
+    print('미션$missionNumber 완료 상태 변경: $newState');
+    return newState;
+  }
+
+  // 미션 완료 상태 확인
+  static bool isMissionCompleted(int missionNumber) {
+    if (_prefs == null) return false;
+
+    final key =
+        missionNumber == 1 ? _mission1CompletedKey : _mission2CompletedKey;
+    return _prefs!.getBool(key) ?? false;
+  }
+
+  // 오늘의 미션 초기화 (매일 자정에 호출 예정)
+  static Future<void> resetDailyMissions() async {
+    if (_prefs == null) await init();
+
+    await _prefs!.remove(_mission1CompletedKey);
+    await _prefs!.remove(_mission2CompletedKey);
+    print('일일 미션 초기화 완료');
+  }
+
+  // 모든 미션 데이터 삭제 (설정 초기화용)
+  static Future<void> clearAllMissionData() async {
+    if (_prefs == null) await init();
+
+    await _prefs!.remove(_mission1TimeKey);
+    await _prefs!.remove(_mission2TimeKey);
+    await _prefs!.remove(_mission1CompletedKey);
+    await _prefs!.remove(_mission2CompletedKey);
+    print('모든 미션 데이터 삭제 완료');
+  }
+
+  // 디버깅용: 현재 저장된 모든 미션 데이터 출력
+  static void debugMissionData() {
+    if (_prefs == null) return;
+
+    print('\n=== 미션 데이터 현황 ===');
+    print('미션1 시간: ${getMissionTime(1)}');
+    print('미션2 시간: ${getMissionTime(2)}');
+    print('미션1 완료여부: ${isMissionCompleted(1)}');
+    print('미션2 완료여부: ${isMissionCompleted(2)}');
+    print('=====================\n');
+  }
+}

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -5,6 +5,8 @@ class MissionService {
   static const String _mission2TimeKey = 'mission2_time';
   static const String _mission1CompletedKey = 'mission1_completed';
   static const String _mission2CompletedKey = 'mission2_completed';
+  static const String _mission1CompletedAtKey = 'mission1_completed_at';
+  static const String _mission2CompletedAtKey = 'mission2_completed_at';
   static SharedPreferences? _prefs;
 
   // SharedPreferences 초기화
@@ -35,7 +37,7 @@ class MissionService {
     return time;
   }
 
-  // 미션 완료 상태 토글
+  // 미션 완료 상태 토글 (완료 시간 포함)
   static Future<bool> toggleMissionComplete(int missionNumber) async {
     if (_prefs == null) await init();
 
@@ -43,9 +45,10 @@ class MissionService {
         missionNumber == 1 ? _mission1CompletedKey : _mission2CompletedKey;
     final currentState = _prefs!.getBool(key) ?? false;
     final newState = !currentState;
-    await _prefs!.setBool(key, newState);
 
-    print('미션$missionNumber 완료 상태 변경: $newState');
+    await _prefs!.setBool(key, newState);
+    await saveMissionCompletedAt(missionNumber, newState);
+
     return newState;
   }
 
@@ -88,5 +91,33 @@ class MissionService {
     print('미션1 완료여부: ${isMissionCompleted(1)}');
     print('미션2 완료여부: ${isMissionCompleted(2)}');
     print('=====================\n');
+  }
+
+  // 미션 완료 시간 저장
+  static Future<void> saveMissionCompletedAt(
+      int missionNumber, bool completed) async {
+    if (_prefs == null) await init();
+
+    final key =
+        missionNumber == 1 ? _mission1CompletedAtKey : _mission2CompletedAtKey;
+    if (completed) {
+      final now = DateTime.now();
+      await _prefs!.setString(key, now.toIso8601String());
+    } else {
+      await _prefs!.remove(key);
+    }
+  }
+
+  // 미션 완료 시간 가져오기
+  static String? getMissionCompletedAt(int missionNumber) {
+    if (_prefs == null) return null;
+
+    final key =
+        missionNumber == 1 ? _mission1CompletedAtKey : _mission2CompletedAtKey;
+    final dateString = _prefs!.getString(key);
+    if (dateString == null) return null;
+
+    final dateTime = DateTime.parse(dateString);
+    return '${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
   }
 }

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -1,21 +1,46 @@
 import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:convert';
+import '../models/mission.dart';
 
 class MissionService {
   static const String _mission1TimeKey = 'mission1_time';
   static const String _mission2TimeKey = 'mission2_time';
   static const String _mission1CompletedKey = 'mission1_completed';
   static const String _mission2CompletedKey = 'mission2_completed';
-  static const String _mission1CompletedAtKey = 'mission1_completed_at';
-  static const String _mission2CompletedAtKey = 'mission2_completed_at';
   static SharedPreferences? _prefs;
+
+  // 날짜별 키 생성 (예: 'mission_2024-03-15')
+  static String _getKeyForDate(DateTime date) {
+    return 'mission_${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
 
   // SharedPreferences 초기화
   static Future<void> init() async {
-    if (_prefs != null) return; // 이미 초기화되어 있다면 스킵
+    if (_prefs == null) {
+      _prefs = await SharedPreferences.getInstance();
+      print('SharedPreferences 초기화 완료');
+      _checkAndResetDaily(); // 자정 지난 후 첫 실행시 초기화
+    }
+  }
 
-    _prefs = await SharedPreferences.getInstance();
-    print('SharedPreferences 초기화 완료');
-    debugStorageContent(); // 현재 저장된 모든 데이터 출력
+  // 자정 지났는지 확인하고 초기화
+  static Future<void> _checkAndResetDaily() async {
+    final lastResetKey = 'last_reset_date';
+    final today = DateTime.now();
+    final lastResetStr = _prefs?.getString(lastResetKey);
+
+    if (lastResetStr != null) {
+      final lastReset = DateTime.parse(lastResetStr);
+      if (today.day != lastReset.day ||
+          today.month != lastReset.month ||
+          today.year != lastReset.year) {
+        // 날짜가 변경되었으면 초기화
+        await resetDailyMissions();
+      }
+    }
+
+    // 마지막 초기화 날짜 업데이트
+    await _prefs?.setString(lastResetKey, today.toIso8601String());
   }
 
   // 미션 시간 저장
@@ -41,28 +66,89 @@ class MissionService {
     return time;
   }
 
-  // 미션 완료 상태 토글 (완료 시간 포함)
-  static Future<bool> toggleMissionComplete(int missionNumber) async {
+  // 미션 완료 상태 토글 및 히스토리 저장
+  static Future<bool> toggleMissionComplete(String missionId) async {
     if (_prefs == null) await init();
 
-    final key =
-        missionNumber == 1 ? _mission1CompletedKey : _mission2CompletedKey;
-    final currentState = _prefs!.getBool(key) ?? false;
-    final newState = !currentState;
+    final today = DateTime.now();
+    final key = _getKeyForDate(today);
 
-    await _prefs!.setBool(key, newState);
-    await saveMissionCompletedAt(missionNumber, newState);
+    // 현재 날짜의 미션 데이터 가져오기
+    final missions = await getTodaysMissions();
 
-    return newState;
+    // 해당 미션의 상태 변경
+    final updatedMissions = missions.map((mission) {
+      if (mission.id == missionId) {
+        return Mission(
+          id: mission.id,
+          time: mission.time,
+          isCompleted: !mission.isCompleted,
+          completedAt: !mission.isCompleted ? DateTime.now() : null,
+          date: today,
+        );
+      }
+      return mission;
+    }).toList();
+
+    // 변경된 데이터 저장
+    final missionJsonList =
+        updatedMissions.map((m) => jsonEncode(m.toJson())).toList();
+    await _prefs!.setStringList(key, missionJsonList);
+
+    // 변경된 미션의 새로운 상태 반환
+    final targetMission = updatedMissions.firstWhere((m) => m.id == missionId);
+    return targetMission.isCompleted;
   }
 
-  // 미션 완료 상태 확인
-  static bool isMissionCompleted(int missionNumber) {
-    if (_prefs == null) return false;
+  // 오늘의 미션 데이터 가져오기
+  static Future<List<Mission>> getTodaysMissions() async {
+    if (_prefs == null) await init();
 
-    final key =
-        missionNumber == 1 ? _mission1CompletedKey : _mission2CompletedKey;
-    return _prefs!.getBool(key) ?? false;
+    final key = _getKeyForDate(DateTime.now());
+    final missionJsonList = _prefs!.getStringList(key) ?? [];
+
+    if (missionJsonList.isEmpty) {
+      // 해당 날짜의 첫 접속이면 미션 초기화
+      final missions = [
+        if (getMissionTime(1) != null)
+          Mission(
+            id: 'mission1',
+            time: getMissionTime(1)!,
+            isCompleted: false,
+            date: DateTime.now(),
+          ),
+        if (getMissionTime(2) != null)
+          Mission(
+            id: 'mission2',
+            time: getMissionTime(2)!,
+            isCompleted: false,
+            date: DateTime.now(),
+          ),
+      ];
+
+      // 초기 미션 데이터 저장
+      final initialJsonList =
+          missions.map((m) => jsonEncode(m.toJson())).toList();
+      await _prefs!.setStringList(key, initialJsonList);
+      return missions;
+    }
+
+    // 저장된 미션 데이터 반환
+    return missionJsonList
+        .map((json) => Mission.fromJson(jsonDecode(json)))
+        .toList();
+  }
+
+  // 특정 날짜의 미션 히스토리 가져오기
+  static Future<List<Mission>> getMissionHistory(DateTime date) async {
+    if (_prefs == null) await init();
+
+    final key = _getKeyForDate(date);
+    final missionJsonList = _prefs!.getStringList(key) ?? [];
+
+    return missionJsonList
+        .map((json) => Mission.fromJson(jsonDecode(json)))
+        .toList();
   }
 
   // 오늘의 미션 초기화 (매일 자정에 호출 예정)
@@ -85,47 +171,24 @@ class MissionService {
     print('모든 미션 데이터 삭제 완료');
   }
 
-  // 디버깅용: 현재 저장된 모든 미션 데이터 출력
-  static void debugMissionData() {
+  // 디버깅용: 모든 히스토리 출력
+  static void debugMissionHistory() {
     if (_prefs == null) return;
 
-    print('\n=== 미션 데이터 현황 ===');
-    print('미션1 시간: ${getMissionTime(1)}');
-    print('미션2 시간: ${getMissionTime(2)}');
-    print('미션1 완료여부: ${isMissionCompleted(1)}');
-    print('미션2 완료여부: ${isMissionCompleted(2)}');
-    print('=====================\n');
-  }
-
-  // 미션 완료 시간 저장
-  static Future<void> saveMissionCompletedAt(
-      int missionNumber, bool completed) async {
-    if (_prefs == null) await init();
-
-    final key =
-        missionNumber == 1 ? _mission1CompletedAtKey : _mission2CompletedAtKey;
-    if (completed) {
-      final now = DateTime.now();
-      await _prefs!.setString(key, now.toIso8601String());
-    } else {
-      await _prefs!.remove(key);
+    print('\n=== 미션 히스토리 ===');
+    final allKeys =
+        _prefs!.getKeys().where((key) => key.startsWith('mission_'));
+    for (final key in allKeys) {
+      final missions = _prefs!.getStringList(key) ?? [];
+      print('$key: ${missions.length} missions');
+      for (final mission in missions) {
+        print('  $mission');
+      }
     }
+    print('==================\n');
   }
 
-  // 미션 완료 시간 가져오기
-  static String? getMissionCompletedAt(int missionNumber) {
-    if (_prefs == null) return null;
-
-    final key =
-        missionNumber == 1 ? _mission1CompletedAtKey : _mission2CompletedAtKey;
-    final dateString = _prefs!.getString(key);
-    if (dateString == null) return null;
-
-    final dateTime = DateTime.parse(dateString);
-    return '${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
-  }
-
-  // 저장소의 모든 데이터 출력 (디버깅용)
+  // 저장소의 모든 데이터 출력 (버깅용)
   static void debugStorageContent() {
     if (_prefs == null) {
       print('SharedPreferences가 초기화되지 않음');

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,0 +1,43 @@
+platform :osx, '10.14'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -152,6 +168,102 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "3b9febd815c9ca29c9e3520d50ec32f49157711e143b7a4ca039eb87e8ade5ab"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "07e050c7cd39bad516f8d64c455f04508d09df104be326d8c02551590a0d513d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -221,6 +333,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.2.5"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.5.3 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   go_router: ^14.3.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 작업 내용
(코드는 cursor ai 프롬프팅을 통해 작성되었습니다)
- 개발환경에서 db 역할을 대신 수행할 shared_preferences 추가 (기기 로컬 스토리지 개념인듯)
  - 패키지 설치
- Mission 모델 / MissionService 클래스 추가 및 비즈니스 로직 작성
  - 미션 시간 설정, 성공 여부 등을 스토리지에 저장하여 개별환경에서도 미션정보가 유지되도록
  - 매일 자정이 지나면 새로운 미션 추가 (기존 미션도 저장)
- Home 화면 기능 및 ui 구현
  - 체크박스 체크 시 미션 수행. 해제 시 취소
  - 미션시간이 지났는데 수행이 안 된 경우 경고 메시지 표기
  - 미션이 완료된 경우 완료 시간 표기
- showTimePicker를 사용하여 미션시간 input에서 시간을 설정할 수 있도록 변경

## 작업사항

Commits on Nov 1, 2024
- [chore: 로컬 스토리지 활용을 위한 shared_preferences 추가](https://github.com/buku-buku/notiyou/pull/1/commits/fb2ce525110ec215252225501b8b61a72dbd4100)

Commits on Nov 2, 2024
- [feat: showTimePicker를 사용하여 미션 시간 선택가능하도록 수정](https://github.com/buku-buku/notiyou/pull/1/commits/6baa9691bcabecd0c58bef00b7b5d8f18159dddf)
- [feat: MissionService 클래스 추가](https://github.com/buku-buku/notiyou/pull/1/commits/86bd355f7f33fb2df56305c96c74857067636e33)
- [feat: 미션시간 설정완료 시, shared preferences에 미션 정보 저장](https://github.com/buku-buku/notiyou/pull/1/commits/c0883e0e1ae252f0fa1b16b05b01417193ac4928)
- [chore: shared preferences 패키지 추가](https://github.com/buku-buku/notiyou/pull/1/commits/0cf0bcc449017100c3436d225d409473a88d83fc)
- [feat: 스토리지에 저장된 미션 시간을 홈화면에 표기](https://github.com/buku-buku/notiyou/pull/1/commits/74fba50d2b05aa6164f75f45cf18d25917410b2b)
- [feat: 미션 수행에 따른 UI 및 스토리지 상태 변화 기능 추가](https://github.com/buku-buku/notiyou/pull/1/commits/44e8748cb8c949be93f4c6da8824944af266b675)
- [refactor: 스토리지 저장 정보 디버깅용 로그 추가](https://github.com/buku-buku/notiyou/pull/1/commits/902c6f880ced8ab48a21bde07942adc624c3038f)
- [feat: 앱 재시작 시 미션시간 스토리지로부터 업데이트](https://github.com/buku-buku/notiyou/pull/1/commits/008e3766632077398afcd89aaf7e560a1116ffd0)
- [feat: main 함수 최상단에 flutter 바인딩 및 미션서비스 초기화](https://github.com/buku-buku/notiyou/pull/1/commits/968190f46e8ce16d0089e81e5537f0fee15bed3c)

Commits on Nov 3, 2024
- [refactor: Mission 모델을 활용하는 방식으로 코드 전반적인 동작 방식 수정](https://github.com/buku-buku/notiyou/pull/1/commits/f64b8c000d552b388a59b653a635f87ce8e6a848)
- [refactor: 사용하지 않는 디버깅로그 삭제 및 앱 최초실행 스토리지 디버깅 로그하도록 변경](https://github.com/buku-buku/notiyou/pull/1/commits/9ee87ddf9faf04f8f982499e47618791eb61ee24)

## 스크린샷
- config 페이지
![스크린샷 2024-11-03 오후 10 23 08](https://github.com/user-attachments/assets/71a97bd4-e98c-45de-9c10-e11ee47a20b1)


- home 페이지
![스크린샷 2024-11-03 오후 10 22 49](https://github.com/user-attachments/assets/d9ada1a3-1d00-461f-8b55-838064f62e96)


