### PR TITLE
[refactor] mission_service에서 미션 데이터를 다루는 로직을 별도 클래스로 추출

### DIFF
--- a/lib/repositories/mission_repository.dart
+++ b/lib/repositories/mission_repository.dart
@@ -4,6 +4,7 @@ import '../models/mission.dart';
 
 class MissionRepository {
   static SharedPreferences? _prefs;
+  static const String _missionStoreKey = 'mission';
 
   // SharedPreferences 초기화
   static Future<void> init() async {
@@ -14,7 +15,7 @@ class MissionRepository {
 
   // 날짜별 키 생성
   static String getKeyForDate(DateTime date) {
-    return 'mission_${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+    return '${_missionStoreKey}_${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
   }
 
   // 미션 데이터 저장
@@ -41,5 +42,18 @@ class MissionRepository {
     if (_prefs == null) await init();
 
     await _prefs!.remove(key);
+  }
+
+  // 모든 미션 삭제
+  static Future<void> clearAllMissions() async {
+    if (_prefs == null) await init();
+
+    final futures = _prefs!
+        .getKeys()
+        .where((key) => key.startsWith(_missionStoreKey))
+        .map((key) => _prefs!.remove(key))
+        .toList();
+
+    await Future.wait(futures);
   }
 }

--- a/lib/repositories/mission_repository.dart
+++ b/lib/repositories/mission_repository.dart
@@ -14,12 +14,14 @@ class MissionRepository {
   }
 
   // 날짜별 키 생성
-  static String getKeyForDate(DateTime date) {
+  static String _getKeyForDate(DateTime date) {
     return '${_missionStoreKey}_${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
   }
 
   // 미션 데이터 저장
-  static Future<void> saveMissions(String key, List<Mission> missions) async {
+  static Future<void> saveMissions(
+      DateTime date, List<Mission> missions) async {
+    final key = _getKeyForDate(date);
     if (_prefs == null) await init();
 
     final missionJsonList =
@@ -28,7 +30,8 @@ class MissionRepository {
   }
 
   // 미션 데이터 불러오기
-  static Future<List<Mission>> getMissions(String key) async {
+  static Future<List<Mission>> getMissions(DateTime date) async {
+    final key = _getKeyForDate(date);
     if (_prefs == null) await init();
 
     final missionJsonList = _prefs!.getStringList(key) ?? [];
@@ -38,7 +41,8 @@ class MissionRepository {
   }
 
   // 특정 키의 데이터 삭제
-  static Future<void> removeData(String key) async {
+  static Future<void> removeData(DateTime date) async {
+    final key = _getKeyForDate(date);
     if (_prefs == null) await init();
 
     await _prefs!.remove(key);

--- a/lib/repositories/mission_repository.dart
+++ b/lib/repositories/mission_repository.dart
@@ -1,0 +1,45 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:convert';
+import '../models/mission.dart';
+
+class MissionRepository {
+  static SharedPreferences? _prefs;
+
+  // SharedPreferences 초기화
+  static Future<void> init() async {
+    if (_prefs == null) {
+      _prefs = await SharedPreferences.getInstance();
+    }
+  }
+
+  // 날짜별 키 생성
+  static String getKeyForDate(DateTime date) {
+    return 'mission_${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+
+  // 미션 데이터 저장
+  static Future<void> saveMissions(String key, List<Mission> missions) async {
+    if (_prefs == null) await init();
+
+    final missionJsonList =
+        missions.map((m) => jsonEncode(m.toJson())).toList();
+    await _prefs!.setStringList(key, missionJsonList);
+  }
+
+  // 미션 데이터 불러오기
+  static Future<List<Mission>> getMissions(String key) async {
+    if (_prefs == null) await init();
+
+    final missionJsonList = _prefs!.getStringList(key) ?? [];
+    return missionJsonList
+        .map((json) => Mission.fromJson(jsonDecode(json)))
+        .toList();
+  }
+
+  // 특정 키의 데이터 삭제
+  static Future<void> removeData(String key) async {
+    if (_prefs == null) await init();
+
+    await _prefs!.remove(key);
+  }
+}

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -5,8 +5,6 @@ import '../repositories/mission_repository.dart';
 class MissionService {
   static const String _mission1TimeKey = 'mission1_time';
   static const String _mission2TimeKey = 'mission2_time';
-  static const String _mission1CompletedKey = 'mission1_completed';
-  static const String _mission2CompletedKey = 'mission2_completed';
   static SharedPreferences? _prefs;
 
   // SharedPreferences 초기화
@@ -66,10 +64,9 @@ class MissionService {
     if (_prefs == null) await init();
 
     final today = DateTime.now();
-    final key = MissionRepository.getKeyForDate(today);
 
     // 현재 날짜의 미션 데이터 가져오기
-    final missions = await MissionRepository.getMissions(key);
+    final missions = await MissionRepository.getMissions(today);
 
     // 해당 미션의 상태 변경
     final updatedMissions = missions.map((mission) {
@@ -86,7 +83,7 @@ class MissionService {
     }).toList();
 
     // 변경된 데이터 저장
-    await MissionRepository.saveMissions(key, updatedMissions);
+    await MissionRepository.saveMissions(DateTime.now(), updatedMissions);
 
     // 변경된 미션의 새로운 상태 반환
     final targetMission = updatedMissions.firstWhere((m) => m.id == missionId);
@@ -97,8 +94,7 @@ class MissionService {
   static Future<List<Mission>> getTodaysMissions() async {
     if (_prefs == null) await init();
 
-    final key = MissionRepository.getKeyForDate(DateTime.now());
-    final missions = await MissionRepository.getMissions(key);
+    final missions = await MissionRepository.getMissions(DateTime.now());
 
     if (missions.isEmpty) {
       // 해당 날짜의 첫 접속이면 미션 초기화
@@ -120,7 +116,7 @@ class MissionService {
       ];
 
       // 초기 미션 데이터 저장
-      await MissionRepository.saveMissions(key, newMissions);
+      await MissionRepository.saveMissions(DateTime.now(), newMissions);
       return newMissions;
     }
 
@@ -132,16 +128,14 @@ class MissionService {
   static Future<List<Mission>> getMissionHistory(DateTime date) async {
     if (_prefs == null) await init();
 
-    final key = MissionRepository.getKeyForDate(date);
-    return await MissionRepository.getMissions(key);
+    return await MissionRepository.getMissions(date);
   }
 
   // 오늘의 미션 초기화 (매일 자정에 호출 예정)
   static Future<void> resetDailyMissions() async {
     if (_prefs == null) await init();
 
-    await MissionRepository.removeData(_mission1CompletedKey);
-    await MissionRepository.removeData(_mission2CompletedKey);
+    await MissionRepository.removeData(DateTime.now());
     print('일일 미션 초기화 완료');
   }
 

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -9,6 +9,7 @@ class MissionService {
 
   // SharedPreferences 초기화
   static Future<void> init() async {
+    await MissionRepository.init();
     if (_prefs == null) {
       _prefs = await SharedPreferences.getInstance();
       print('SharedPreferences 초기화 완료');

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -149,10 +149,7 @@ class MissionService {
   static Future<void> clearAllMissionData() async {
     if (_prefs == null) await init();
 
-    await MissionRepository.removeData(_mission1TimeKey);
-    await MissionRepository.removeData(_mission2TimeKey);
-    await MissionRepository.removeData(_mission1CompletedKey);
-    await MissionRepository.removeData(_mission2CompletedKey);
+    await MissionRepository.clearAllMissions();
     print('모든 미션 데이터 삭제 완료');
   }
 


### PR DESCRIPTION
## 개요 
향후에 미션 데이터는 클라이언트에서뿐 아니라 서버상에서 다루어지게 될 데이터이기도 하다보니,
이후 복잡해질 수 있는 가능성을 염두하여 미션 데이터를 다루는 로직을 별도 클래스로 분리해두려고 합니다.

## 작업 내용

- [ca2d66e](https://github.com/buku-buku/notiyou/pull/3/commits/ca2d66e7506c21deb7dbd3ee39ed95e4becaa945) 기존의 mission_service에서 미션 데이터를 다루는 로직들을 추출하여 mission_repository 클래스를 작성하였습니다.
- [e70706e](https://github.com/buku-buku/notiyou/pull/3/commits/e70706ead9c5ea837d3720748682bc929ce7c23e) 모든 미션 데이터 삭제 메서드를 mission_repository에 추가하였습니다.
- [75c8936](https://github.com/buku-buku/notiyou/pull/3/commits/75c8936bbc13493d06d6218fecfa932f6a57a094) 미션 데이터에 접근하기 위한 키를 레포지토리내에서 캡슐화하여 관리하도록 하고, 관련된 모든 메서드를 DateTime 객체를 인자로 전달받는 형식으로 변경하였습니다.


## To-Be..

- 미션이 설정되어 있는 상황으로 가정하였을때, 미션 시간을 변경할때 오늘의 미션 시간도 변경할지 말지를 유저에게 선택권을 주는게 좋을것 같습니다. 이를 위한 개발을 진행할 예정입니다.
- 미션에 대한 완료 여부 기록도 mission_repository에서 관리하는편이 좋을것 같습니다.