### PR TITLE
[feature] 앱 실행시 오늘을 제외한 로컬상의 미션 데이터를 모두 제거하도록 처리

### DIFF
--- a/lib/models/mission.dart
+++ b/lib/models/mission.dart
@@ -17,6 +17,21 @@ class Mission {
     required this.date,
   });
 
+  Mission copyWith({
+    String? id,
+    TimeOfDay? time,
+    bool? isCompleted,
+    DateTime? completedAt,
+    DateTime? date,
+  }) =>
+      Mission(
+        id: id ?? this.id,
+        time: time ?? this.time,
+        isCompleted: isCompleted ?? this.isCompleted,
+        completedAt: completedAt ?? this.completedAt,
+        date: date ?? this.date,
+      );
+
   Map<String, dynamic> toJson() => {
         'id': id,
         'time': TimeUtils.stringifyTime(time),

--- a/lib/models/mission.dart
+++ b/lib/models/mission.dart
@@ -1,6 +1,10 @@
+import 'package:flutter/material.dart';
+
+import '../utils/time_utils.dart';
+
 class Mission {
   final String id;
-  final String time;
+  final TimeOfDay time;
   final bool isCompleted;
   final DateTime? completedAt;
   final DateTime date;
@@ -15,7 +19,7 @@ class Mission {
 
   Map<String, dynamic> toJson() => {
         'id': id,
-        'time': time,
+        'time': TimeUtils.stringifyTime(time),
         'isCompleted': isCompleted,
         'completedAt': completedAt?.toIso8601String(),
         'date': date.toIso8601String(),
@@ -23,7 +27,7 @@ class Mission {
 
   factory Mission.fromJson(Map<String, dynamic> json) => Mission(
         id: json['id'],
-        time: json['time'],
+        time: TimeUtils.parseTime(json['time']),
         isCompleted: json['isCompleted'],
         completedAt: json['completedAt'] != null
             ? DateTime.parse(json['completedAt'])
@@ -38,8 +42,8 @@ class Mission {
       date.year,
       date.month,
       date.day,
-      int.parse(time.split(':')[0]),
-      int.parse(time.split(':')[1]),
+      time.hour,
+      time.minute,
     ).isBefore(now);
   }
 

--- a/lib/repositories/mission_repository.dart
+++ b/lib/repositories/mission_repository.dart
@@ -46,8 +46,7 @@ class MissionRepository {
   }
 
   // 미션 데이터 저장
-  static Future<void> saveMissions(
-      DateTime date, List<Mission> missions) async {
+  static Future<void> setMissions(DateTime date, List<Mission> missions) async {
     final key = _getKeyForDate(date);
     if (_prefs == null) await init();
 
@@ -56,8 +55,20 @@ class MissionRepository {
     await _prefs!.setStringList(key, missionJsonList);
   }
 
+  // 미션 데이터 수정
+  static Future<void> updateMission(DateTime date, Mission mission) async {
+    // mission id로 기존 미션 찾기
+    final missions = await findMissions(date);
+    final updatedMissions = missions.map((m) {
+      if (m.id == mission.id) return mission;
+      return m;
+    }).toList();
+
+    await setMissions(date, updatedMissions);
+  }
+
   // 미션 데이터 불러오기
-  static Future<List<Mission>> getMissions(DateTime date) async {
+  static Future<List<Mission>> findMissions(DateTime date) async {
     final key = _getKeyForDate(date);
     if (_prefs == null) await init();
 
@@ -65,6 +76,12 @@ class MissionRepository {
     return missionJsonList
         .map((json) => Mission.fromJson(jsonDecode(json)))
         .toList();
+  }
+
+  // 미션 아이디로 미션 찾기
+  static Future<Mission?> findMissionById(DateTime date, String id) async {
+    final missions = await findMissions(date);
+    return missions.firstWhere((m) => m.id == id);
   }
 
   // 특정 키의 데이터 삭제

--- a/lib/repositories/mission_repository.dart
+++ b/lib/repositories/mission_repository.dart
@@ -7,12 +7,14 @@ import '../utils/time_utils.dart';
 class MissionRepository {
   static SharedPreferences? _prefs;
   static const String _missionStoreKey = 'mission';
+  static const String _lastResetKey = 'last_reset_date';
 
   // SharedPreferences 초기화
   static Future<void> init() async {
     if (_prefs == null) {
       _prefs = await SharedPreferences.getInstance();
     }
+    await checkAndResetDailyMissions();
   }
 
   // 미션 별 키 생성
@@ -21,6 +23,24 @@ class MissionRepository {
   // 날짜별 키 생성
   static String _getKeyForDate(DateTime date) {
     return '${_missionStoreKey}_${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+
+  // 자정 지났는지 확인하고 초기화
+  static Future<void> checkAndResetDailyMissions() async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final lastResetStr = _prefs?.getString(_lastResetKey);
+
+    if (lastResetStr != null) {
+      final lastReset = DateTime.parse(lastResetStr);
+
+      if (today.compareTo(lastReset) != 0) {
+        await removeMissionsFrom(lastReset);
+      }
+    }
+
+    // 마지막 초기화 날짜 업데이트
+    await _prefs?.setString(_lastResetKey, today.toIso8601String());
   }
 
   // 미션 시간 조회
@@ -85,7 +105,7 @@ class MissionRepository {
   }
 
   // 특정 키의 데이터 삭제
-  static Future<void> removeData(DateTime date) async {
+  static Future<void> removeMissionsFrom(DateTime date) async {
     final key = _getKeyForDate(date);
     if (_prefs == null) await init();
 
@@ -103,5 +123,37 @@ class MissionRepository {
         .toList();
 
     await Future.wait(futures);
+  }
+
+  // 디버깅용: 모든 히스토리 출력
+  static void debugMissionHistory() {
+    if (_prefs == null) return;
+
+    print('\n=== 미션 히스토리 ===');
+    final allKeys =
+        _prefs!.getKeys().where((key) => key.startsWith(_missionStoreKey));
+    for (final key in allKeys) {
+      final missions = _prefs!.getStringList(key) ?? [];
+      print('$key: ${missions.length} missions');
+      for (final mission in missions) {
+        print('  $mission');
+      }
+    }
+    print('==================\n');
+  }
+
+  // 저장소의 모든 데이터 출력 (버깅용)
+  static void debugStorageContent() {
+    if (_prefs == null) {
+      print('SharedPreferences가 초기화되지 않음');
+      return;
+    }
+
+    print('\n=== 저장소 전체 데이터 ===');
+    final keys = _prefs!.getKeys();
+    for (final key in keys) {
+      print('$key: ${_prefs!.get(key)}');
+    }
+    print('=======================\n');
   }
 }

--- a/lib/repositories/mission_repository.dart
+++ b/lib/repositories/mission_repository.dart
@@ -1,6 +1,8 @@
+import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:convert';
 import '../models/mission.dart';
+import '../utils/time_utils.dart';
 
 class MissionRepository {
   static SharedPreferences? _prefs;
@@ -13,9 +15,34 @@ class MissionRepository {
     }
   }
 
+  // 미션 별 키 생성
+  static String _getMissionKey(int missionNumber) => 'mission$missionNumber';
+
   // 날짜별 키 생성
   static String _getKeyForDate(DateTime date) {
     return '${_missionStoreKey}_${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+
+  // 미션 시간 조회
+  static TimeOfDay? getMissionTime(int missionNumber) {
+    final key = _getMissionKey(missionNumber);
+    final timeStr = _prefs!.getString(key);
+
+    if (timeStr == null) return null;
+
+    return TimeUtils.parseTime(timeStr);
+  }
+
+  // 미션 시간 설정
+  static Future<void> setMissionTime(int missionNumber, TimeOfDay time) async {
+    final key = _getMissionKey(missionNumber);
+    await _prefs!.setString(key, TimeUtils.stringifyTime(time));
+  }
+
+  // 미션 시간 초기화
+  static Future<void> clearMissionTime(int missionNumber) async {
+    final key = _getMissionKey(missionNumber);
+    await _prefs!.remove(key);
   }
 
   // 미션 데이터 저장

--- a/lib/screens/config_page.dart
+++ b/lib/screens/config_page.dart
@@ -23,47 +23,15 @@ class _ConfigPageState extends State<ConfigPage> {
   }
 
   Future<void> _loadSavedTimes() async {
-    final mission1String = MissionService.getMissionTime(1);
-    final mission2String = MissionService.getMissionTime(2);
-
-    print('저장된 미션1 시간: $mission1String');
-    print('저장된 미션2 시간: $mission2String');
-
     setState(() {
-      if (mission1String != null) {
-        final parts = mission1String.split(':');
-        _mission1Time = TimeOfDay(
-          hour: int.parse(parts[0]),
-          minute: int.parse(parts[1]),
-        );
-      }
-
-      if (mission2String != null) {
-        final parts = mission2String.split(':');
-        _mission2Time = TimeOfDay(
-          hour: int.parse(parts[0]),
-          minute: int.parse(parts[1]),
-        );
-      }
+      _mission1Time = MissionService.getMissionTime(1);
+      _mission2Time = MissionService.getMissionTime(2);
     });
   }
 
-  String _timeToString(TimeOfDay time) {
-    return '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
-  }
-
   Future<void> _saveTimes() async {
-    if (_mission1Time != null) {
-      await MissionService.saveMissionTime(1, _timeToString(_mission1Time!));
-    } else {
-      await MissionService.saveMissionTime(1, null);
-    }
-
-    if (_mission2Time != null) {
-      await MissionService.saveMissionTime(2, _timeToString(_mission2Time!));
-    } else {
-      await MissionService.saveMissionTime(2, null);
-    }
+    await MissionService.saveMissionTime(1, _mission1Time);
+    await MissionService.saveMissionTime(2, _mission2Time);
   }
 
   Future<void> _selectTime(BuildContext context, bool isFirstMission) async {

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -55,7 +55,7 @@ class _HomePageState extends State<HomePage> {
                 ),
               ListTile(
                 title: Text(
-                  '미션시간 ${mission.id} (${mission.time})',
+                  '미션시간 ${mission.id} (${mission.time.format(context)})',
                   style: TextStyle(
                     color: mission.expired ? Colors.red : null,
                   ),

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -1,46 +1,16 @@
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../models/mission.dart';
 import '../repositories/mission_repository.dart';
 
 class MissionService {
-  static SharedPreferences? _prefs;
-
   // SharedPreferences 초기화
   static Future<void> init() async {
     await MissionRepository.init();
-    if (_prefs == null) {
-      _prefs = await SharedPreferences.getInstance();
-      print('SharedPreferences 초기화 완료');
-      _checkAndResetDaily(); // 자정 지난 후 첫 실행시 초기화
-    }
-  }
-
-  // 자정 지났는지 확인하고 초기화
-  static Future<void> _checkAndResetDaily() async {
-    final lastResetKey = 'last_reset_date';
-    final today = DateTime.now();
-    final lastResetStr = _prefs?.getString(lastResetKey);
-
-    if (lastResetStr != null) {
-      final lastReset = DateTime.parse(lastResetStr);
-      if (today.day != lastReset.day ||
-          today.month != lastReset.month ||
-          today.year != lastReset.year) {
-        // 날짜가 변경되었으면 초기화
-        await resetDailyMissions();
-      }
-    }
-
-    // 마지막 초기화 날짜 업데이트
-    await _prefs?.setString(lastResetKey, today.toIso8601String());
   }
 
   // 미션 시간 저장
   static Future<void> saveMissionTime(
       int missionNumber, TimeOfDay? time) async {
-    if (_prefs == null) await init();
-
     if (time != null) {
       await MissionRepository.setMissionTime(missionNumber, time);
     } else {
@@ -51,8 +21,6 @@ class MissionService {
 
   // 미션 시간 불러오기
   static TimeOfDay? getMissionTime(int missionNumber) {
-    if (_prefs == null) return null;
-
     final time = MissionRepository.getMissionTime(missionNumber);
     print('미션$missionNumber 시간 불러오기: $time');
     return time;
@@ -60,8 +28,6 @@ class MissionService {
 
   // 미션 완료 상태 토글 및 히스토리 저장
   static Future<bool> toggleMissionComplete(String missionId) async {
-    if (_prefs == null) await init();
-
     final today = DateTime.now();
 
     final mission = await MissionRepository.findMissionById(today, missionId);
@@ -85,8 +51,6 @@ class MissionService {
 
   // 오늘의 미션 데이터 가져오기
   static Future<List<Mission>> getTodaysMissions() async {
-    if (_prefs == null) await init();
-
     final missions = await MissionRepository.findMissions(DateTime.now());
 
     if (missions.isEmpty) {
@@ -119,56 +83,17 @@ class MissionService {
 
   // 특정 날짜의 미션 히스토리 가져오기
   static Future<List<Mission>> getMissionHistory(DateTime date) async {
-    if (_prefs == null) await init();
-
     return await MissionRepository.findMissions(date);
-  }
-
-  // 오늘의 미션 초기화 (매일 자정에 호출 예정)
-  static Future<void> resetDailyMissions() async {
-    if (_prefs == null) await init();
-
-    await MissionRepository.removeData(DateTime.now());
-    print('일일 미션 초기화 완료');
   }
 
   // 모든 미션 데이터 삭제 (설정 초기화용)
   static Future<void> clearAllMissionData() async {
-    if (_prefs == null) await init();
-
     await MissionRepository.clearAllMissions();
     print('모든 미션 데이터 삭제 완료');
   }
 
-  // 디버깅용: 모든 히스토리 출력
-  static void debugMissionHistory() {
-    if (_prefs == null) return;
-
-    print('\n=== 미션 히스토리 ===');
-    final allKeys =
-        _prefs!.getKeys().where((key) => key.startsWith('mission_'));
-    for (final key in allKeys) {
-      final missions = _prefs!.getStringList(key) ?? [];
-      print('$key: ${missions.length} missions');
-      for (final mission in missions) {
-        print('  $mission');
-      }
-    }
-    print('==================\n');
-  }
-
-  // 저장소의 모든 데이터 출력 (버깅용)
+  // 디버깅용: 저장소 전체 데이터 출력
   static void debugStorageContent() {
-    if (_prefs == null) {
-      print('SharedPreferences가 초기화되지 않음');
-      return;
-    }
-
-    print('\n=== 저장소 전체 데이터 ===');
-    final keys = _prefs!.getKeys();
-    for (final key in keys) {
-      print('$key: ${_prefs!.get(key)}');
-    }
-    print('=======================\n');
+    MissionRepository.debugStorageContent();
   }
 }

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -1,10 +1,9 @@
+import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/mission.dart';
 import '../repositories/mission_repository.dart';
 
 class MissionService {
-  static const String _mission1TimeKey = 'mission1_time';
-  static const String _mission2TimeKey = 'mission2_time';
   static SharedPreferences? _prefs;
 
   // SharedPreferences 초기화
@@ -38,24 +37,23 @@ class MissionService {
   }
 
   // 미션 시간 저장
-  static Future<void> saveMissionTime(int missionNumber, String? time) async {
+  static Future<void> saveMissionTime(
+      int missionNumber, TimeOfDay? time) async {
     if (_prefs == null) await init();
 
-    final key = missionNumber == 1 ? _mission1TimeKey : _mission2TimeKey;
     if (time != null) {
-      await _prefs!.setString(key, time);
+      await MissionRepository.setMissionTime(missionNumber, time);
     } else {
-      await _prefs!.remove(key);
+      await MissionRepository.clearMissionTime(missionNumber);
     }
     print('미션$missionNumber 시간 저장: $time');
   }
 
   // 미션 시간 불러오기
-  static String? getMissionTime(int missionNumber) {
+  static TimeOfDay? getMissionTime(int missionNumber) {
     if (_prefs == null) return null;
 
-    final key = missionNumber == 1 ? _mission1TimeKey : _mission2TimeKey;
-    final time = _prefs!.getString(key);
+    final time = MissionRepository.getMissionTime(missionNumber);
     print('미션$missionNumber 시간 불러오기: $time');
     return time;
   }

--- a/lib/utils/time_utils.dart
+++ b/lib/utils/time_utils.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class TimeUtils {
+  // 시간 객체를 문자열로 변환
+  static String stringifyTime(TimeOfDay time) {
+    return '${time.hour}:${time.minute}';
+  }
+
+  // 문자열을 시간 객체로 변환
+  static TimeOfDay parseTime(String timeStr) {
+    final hour = int.parse(timeStr.split(':')[0]);
+    final minute = int.parse(timeStr.split(':')[1]);
+    return TimeOfDay(hour: hour, minute: minute);
+  }
+}

--- a/lib/utils/time_utils.dart
+++ b/lib/utils/time_utils.dart
@@ -12,4 +12,23 @@ class TimeUtils {
     final minute = int.parse(timeStr.split(':')[1]);
     return TimeOfDay(hour: hour, minute: minute);
   }
+
+  static bool isDateString(String dateStr) {
+    return DateTime.tryParse(dateStr) != null;
+  }
+
+  // 날짜 문자열 파싱
+  static DateTime parseDate(String dateStr) {
+    return DateTime.parse(dateStr);
+  }
+
+  // 날짜 문자열 생성
+  static String stringifyDate(DateTime date) {
+    return date.toIso8601String();
+  }
+
+  /// 년월일만 포함하는 날짜 문자열 생성
+  static String stringifyYearMonthDay(DateTime date) {
+    return DateTime(date.year, date.month, date.day).toIso8601String();
+  }
 }


### PR DESCRIPTION
## 개요

이후 미션 데이터는 서버상에서 생성되어 관리될 예정입니다. 
다만 인터넷 연결 불안정 문제 및 서버 미개발 상황인 점을 고려해서 로컬 데이터 관리를 유지할 계획입니다. 로컬 데이터의 경우에는 오늘의 미션을 제외하고는 불필요하기 때문에, 오늘을 제외한 로컬 상의 미션 데이터를 모두 제거하도록 개발합니다.
*지금 다시 보니 기존에도 미션 데이터를 제거하는 처리가 되어 있는것 같네요 ㅎ.. 그냥 로직만 좀 정리했다 정도로 이해해주시면 좋을것 같습니다.

## 작업사항

- [3c3a2b8](https://github.com/buku-buku/notiyou/pull/4/commits/3c3a2b801406a8dbc64a2e795a909439f36e9fa0) "미션 시간"에 대한 데이터 관리 또한 mission_repository에서 관리하도록 변경합니다. 
- [1beaac6](https://github.com/buku-buku/notiyou/pull/4/commits/1beaac68af58ebc23bce2d0217e61b12c16e281b) mission_repository에서 미션 데이터를 변경하는 추가적인 메서드들을 작성하여, mission_service의 코드를 개선합니다.
- [4d1be2d](https://github.com/buku-buku/notiyou/pull/4/commits/4d1be2dbad1431a531c2901da00e6e9f48372394) mission_service에서 shared preferences에 대한 의존성을 제거합니다.
- [8008bbb](https://github.com/buku-buku/notiyou/pull/4/commits/8008bbb59be672cc7aeaba0a01586f4899d0d0bd) 오늘을 제외한 미션 데이터를 제거하는 로직을 재작성합니다.

## Breaking Change
- Mission 모델 스키마가 변경됨에 따라, 기존에 Mission 객체가 로컬상에 저장되어 있을경우 app crash가 발생할 수 있습니다..! 이 경우 main.dart에서 `MissionService.clearAllMissionData()` 를 호출해주면 됩니다.