### PR TITLE
[feature] 미션 시간을 변경할때 오늘의 미션도 업데이트 할지 여부를 묻고, 이에 맞게 처리하도록 변경

### DIFF
--- a/lib/models/mission.dart
+++ b/lib/models/mission.dart
@@ -4,6 +4,7 @@ import '../utils/time_utils.dart';
 
 class Mission {
   final String id;
+  final int missionNumber;
   final TimeOfDay time;
   final bool isCompleted;
   final DateTime? completedAt;
@@ -11,6 +12,7 @@ class Mission {
 
   Mission({
     required this.id,
+    required this.missionNumber,
     required this.time,
     required this.isCompleted,
     this.completedAt,
@@ -19,6 +21,7 @@ class Mission {
 
   Mission copyWith({
     String? id,
+    int? missionNumber,
     TimeOfDay? time,
     bool? isCompleted,
     DateTime? completedAt,
@@ -26,6 +29,7 @@ class Mission {
   }) =>
       Mission(
         id: id ?? this.id,
+        missionNumber: missionNumber ?? this.missionNumber,
         time: time ?? this.time,
         isCompleted: isCompleted ?? this.isCompleted,
         completedAt: completedAt ?? this.completedAt,
@@ -34,6 +38,7 @@ class Mission {
 
   Map<String, dynamic> toJson() => {
         'id': id,
+        'missionNumber': missionNumber,
         'time': TimeUtils.stringifyTime(time),
         'isCompleted': isCompleted,
         'completedAt': completedAt?.toIso8601String(),
@@ -42,6 +47,7 @@ class Mission {
 
   factory Mission.fromJson(Map<String, dynamic> json) => Mission(
         id: json['id'],
+        missionNumber: json['missionNumber'],
         time: TimeUtils.parseTime(json['time']),
         isCompleted: json['isCompleted'],
         completedAt: json['completedAt'] != null

--- a/lib/repositories/mission_repository.dart
+++ b/lib/repositories/mission_repository.dart
@@ -74,7 +74,8 @@ class MissionRepository {
   }
 
   // 미션 데이터 저장
-  static Future<void> setMissions(DateTime date, List<Mission> missions) async {
+  static Future<void> _setMissions(
+      DateTime date, List<Mission> missions) async {
     final key = _getKeyForDate(date);
     if (_prefs == null) await init();
 
@@ -92,7 +93,7 @@ class MissionRepository {
       return m;
     }).toList();
 
-    await setMissions(date, updatedMissions);
+    await _setMissions(date, updatedMissions);
   }
 
   /// ? 이것까지 레포지토리에 위치시키는게 좋을지 고민이 되긴함..
@@ -127,7 +128,7 @@ class MissionRepository {
     if (missionJsonList.isEmpty && createIfEmpty) {
       final newMissions = _createTodaysMissions(date);
 
-      await setMissions(date, newMissions);
+      await _setMissions(date, newMissions);
       return newMissions;
     }
 

--- a/lib/repositories/mission_repository.dart
+++ b/lib/repositories/mission_repository.dart
@@ -95,12 +95,42 @@ class MissionRepository {
     await setMissions(date, updatedMissions);
   }
 
+  /// ? 이것까지 레포지토리에 위치시키는게 좋을지 고민이 되긴함..
+  static List<Mission> _createTodaysMissions(DateTime date) {
+    return [
+      if (getMissionTime(1) != null)
+        Mission(
+          id: 'mission1',
+          time: getMissionTime(1)!,
+          isCompleted: false,
+          date: DateTime.now(),
+        ),
+      if (getMissionTime(2) != null)
+        Mission(
+          id: 'mission2',
+          time: getMissionTime(2)!,
+          isCompleted: false,
+          date: DateTime.now(),
+        ),
+    ];
+  }
+
   // 미션 데이터 불러오기
-  static Future<List<Mission>> findMissions(DateTime date) async {
+  static Future<List<Mission>> findMissions(DateTime date,
+      {bool createIfEmpty = false}) async {
     final key = _getKeyForDate(date);
     if (_prefs == null) await init();
 
     final missionJsonList = _prefs!.getStringList(key) ?? [];
+
+    // 미션 데이터가 없으면 로컬에서 임의로 생성한다.
+    if (missionJsonList.isEmpty && createIfEmpty) {
+      final newMissions = _createTodaysMissions(date);
+
+      await setMissions(date, newMissions);
+      return newMissions;
+    }
+
     return missionJsonList
         .map((json) => Mission.fromJson(jsonDecode(json)))
         .toList();

--- a/lib/screens/config_page.dart
+++ b/lib/screens/config_page.dart
@@ -30,8 +30,40 @@ class _ConfigPageState extends State<ConfigPage> {
   }
 
   Future<void> _saveTimes() async {
-    await MissionService.saveMissionTime(1, _mission1Time);
-    await MissionService.saveMissionTime(2, _mission2Time);
+    // 시간이 변경되었는지 확인
+    final bool hasTimeChanged =
+        _mission1Time != MissionService.getMissionTime(1) ||
+            _mission2Time != MissionService.getMissionTime(2);
+
+    final hasTodayMissions = await MissionService.hasTodayMissions();
+
+    bool? applyToToday;
+    if (hasTimeChanged && hasTodayMissions && context.mounted) {
+      applyToToday = await showDialog<bool>(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text('미션 시간 변경'),
+            content: const Text('변경된 시간을 오늘의 미션에도 적용하시겠습니까?'),
+            actions: <Widget>[
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('아니오'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('예'),
+              ),
+            ],
+          );
+        },
+      );
+    }
+
+    await MissionService.saveMissionTime(1, _mission1Time,
+        isUpdateTodayMission: applyToToday == true);
+    await MissionService.saveMissionTime(2, _mission2Time,
+        isUpdateTodayMission: applyToToday == true);
   }
 
   Future<void> _selectTime(BuildContext context, bool isFirstMission) async {

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -133,6 +133,7 @@ class _HomePageState extends State<HomePage> {
         if (mission.id == missionId) {
           return Mission(
             id: mission.id,
+            missionNumber: mission.missionNumber,
             time: mission.time,
             isCompleted: newState,
             completedAt: newState ? DateTime.now() : null,

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -51,31 +51,8 @@ class MissionService {
 
   // 오늘의 미션 데이터 가져오기
   static Future<List<Mission>> getTodaysMissions() async {
-    final missions = await MissionRepository.findMissions(DateTime.now());
-
-    if (missions.isEmpty) {
-      // 해당 날짜의 첫 접속이면 미션 초기화
-      final newMissions = [
-        if (getMissionTime(1) != null)
-          Mission(
-            id: 'mission1',
-            time: getMissionTime(1)!,
-            isCompleted: false,
-            date: DateTime.now(),
-          ),
-        if (getMissionTime(2) != null)
-          Mission(
-            id: 'mission2',
-            time: getMissionTime(2)!,
-            isCompleted: false,
-            date: DateTime.now(),
-          ),
-      ];
-
-      // 초기 미션 데이터 저장
-      await MissionRepository.setMissions(DateTime.now(), newMissions);
-      return newMissions;
-    }
+    final missions = await MissionRepository.findMissions(DateTime.now(),
+        createIfEmpty: true);
 
     // 저장된 미션 데이터 반환
     return missions;

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -9,12 +9,14 @@ class MissionService {
   }
 
   // 미션 시간 저장
-  static Future<void> saveMissionTime(
-      int missionNumber, TimeOfDay? time) async {
+  static Future<void> saveMissionTime(int missionNumber, TimeOfDay? time,
+      {bool isUpdateTodayMission = true}) async {
     if (time != null) {
-      await MissionRepository.setMissionTime(missionNumber, time);
+      await MissionRepository.setMissionTime(missionNumber, time,
+          isUpdateTodayMission: isUpdateTodayMission);
     } else {
-      await MissionRepository.clearMissionTime(missionNumber);
+      await MissionRepository.clearMissionTime(missionNumber,
+          isUpdateTodayMission: isUpdateTodayMission);
     }
     print('미션$missionNumber 시간 저장: $time');
   }
@@ -47,6 +49,11 @@ class MissionService {
 
     // 변경된 미션의 새로운 상태 반환
     return updatedMission.isCompleted;
+  }
+
+  static Future<bool> hasTodayMissions() async {
+    final missions = await MissionRepository.findMissions(DateTime.now());
+    return missions.isNotEmpty;
   }
 
   // 오늘의 미션 데이터 가져오기


### PR DESCRIPTION
## 개요

https://github.com/buku-buku/notiyou/pull/1#discussion_r1827859770 에서의 논의 내용을 바탕으로 작업이 진행되었습니다.
설정 화면에서 "미션 시간"을 변경하였을때 오늘의 미션은 이에 반영되지 않는 상황이 있습니다.
시나리오에 따라 이것이 자연스러운 경우도, 자연스럽지 않은경우도 있는것 같아서, "미션 시간"을 변경하였을때 오늘의 미션에도 이를 반영할지 여부를 묻고, 이에 따라 적절한 처리를 해주도록 개발을 진행하였습니다.

## 작업 사항

- [b29a09b](https://github.com/buku-buku/notiyou/pull/5/commits/b29a09b0aa9a45eeeae5ee85f1ea7727db35a585) 미션 리스트를 조회할때 조회되는 미션이 없을 경우 오늘의 미션 데이터를 생성하는 처리를 레포지토리로 이동했습니다. 해당 로직은 서버가 생김에 따라 제거될 확률이 높을것 같네요. (서버에서 미션 생성을 실패했을 경우를 고려해서 살려둘수도..)
- [b968ef1](https://github.com/buku-buku/notiyou/pull/5/commits/b968ef1054543234e1f255283c593f3619fafebb) "미션의 생성은 서버에서 처리한다."라는 취지에 맞게 mission_repository에서 미션을 직접적으로 생성하는 `setMissions()` 메서드를 `_setMissions()`로 캡슐화합니다. 
- [076cff8](https://github.com/buku-buku/notiyou/pull/5/commits/076cff877f1d1bef90e93fee72c02c91fafb9bf9) 설정 페이지에서 시간을 변경하였을때 오늘의 미션에도 이를 반영할지 여부를 묻고, 이에 따라 적절한 처리를 하도록 변경하였습니다.
  - [Mission 모델에 missionNumber 필드 추가](https://github.com/buku-buku/notiyou/pull/5/commits/076cff877f1d1bef90e93fee72c02c91fafb9bf9#diff-efa9f21de30c40d731cb3afd64d57487b771da42b920f1cf74a92b194a098e6bR5) 
    -  Mission 모델중 id는 Mission 데이터베이스에서 관리되는 primary key가 될것이라고 염두해두었을때, id를 missionNumber로서 활용하는 것은 부적절하다는 생각이 들었습니다. 따라서 missionNumber 필드를 별도로 추가했습니다.

## To-Be

이후 #6 에서 "미션 시간 관리"와 "미션 관리"에 대한 책임을 분리시킬 예정입니다.
