### PR TITLE
[refactor] 미션 시간을 관리하는 mission_time_repository 작성

### DIFF
--- a/lib/repositories/mission_repository.dart
+++ b/lib/repositories/mission_repository.dart
@@ -5,6 +5,16 @@ import '../models/mission.dart';
 import '../utils/time_utils.dart';
 import './mission_time_repository.dart';
 
+/// 미션 데이터를 관리하는 저장소입니다.
+///
+/// 해당 저장소에서는 미션을 조회하고, 수정하는 메서드만 제공됩니다.
+///
+/// 미션이 생성되는 것은 서버에서 수행될 예정입니다. 클라이언트상에서 생성되는 미션은
+/// 인터넷 연결이 불안정한 환경을 대비한 캐싱 목적으로만 존재합니다.
+///
+/// ⚠️: 로컬의 데이터는 오늘의 데이터만 저장됩니다.
+/// 오늘 이후의 모든 데이터는 앱 실행 시 삭제됩니다.
+
 class MissionRepository {
   static SharedPreferences? _prefs;
   static const String _missionStoreKey = 'mission';
@@ -48,7 +58,9 @@ class MissionRepository {
     return TimeUtils.parseDate(key.replaceFirst('${_missionStoreKey}_', ''));
   }
 
-  // 미션 데이터 저장
+  /// 미션 데이터 저장
+  /// TODO: 실제로 데이터가 생성되는 것은 서버에서 수행될 예정입니다.
+  /// 이후 해당 메서드는 서버에서 데이터를 받아오는 것을 대비한 캐싱 목적으로만 존재합니다.
   static Future<void> _setMissions(
       DateTime date, List<Mission> missions) async {
     final key = _getKeyForDate(date);

--- a/lib/repositories/mission_time_repository.dart
+++ b/lib/repositories/mission_time_repository.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../utils/time_utils.dart';
+
+class MissionTimeRepository {
+  static SharedPreferences? _prefs;
+
+  static Future<void> init() async {
+    if (_prefs == null) {
+      _prefs = await SharedPreferences.getInstance();
+    }
+  }
+
+  static String _getMissionKey(int missionNumber) => 'mission$missionNumber';
+
+  // 미션 시간 조회
+  static TimeOfDay? getMissionTime(int missionNumber) {
+    final key = _getMissionKey(missionNumber);
+    final timeStr = _prefs!.getString(key);
+
+    if (timeStr == null) return null;
+
+    return TimeUtils.parseTime(timeStr);
+  }
+
+  // 미션 시간 설정
+  static Future<void> setMissionTime(int missionNumber, TimeOfDay time) async {
+    final key = _getMissionKey(missionNumber);
+    await _prefs!.setString(key, TimeUtils.stringifyTime(time));
+  }
+
+  // 미션 시간 초기화
+  static Future<void> clearMissionTime(int missionNumber) async {
+    final key = _getMissionKey(missionNumber);
+    await _prefs!.remove(key);
+  }
+}

--- a/lib/repositories/mission_time_repository.dart
+++ b/lib/repositories/mission_time_repository.dart
@@ -2,6 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../utils/time_utils.dart';
 
+/// 미션 시간 데이터를 관리하는 저장소입니다.
+///
+/// 설정된 미션 시간은 서버에 기록되며, 서버에서 미션을 생성할때 사용됩니다.
+///
+/// 다만 인터넷 연결이 불안정한 환경을 대비하여, 로컬에도 미션 시간을 저장합니다.
+/// 해당 값을 통해 로컬상에서 미션이 생성될 수 있습니다.
 class MissionTimeRepository {
   static SharedPreferences? _prefs;
 

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import '../models/mission.dart';
+import '../repositories/mission_time_repository.dart';
 import '../repositories/mission_repository.dart';
 
 class MissionService {
   // SharedPreferences 초기화
   static Future<void> init() async {
+    await MissionTimeRepository.init();
     await MissionRepository.init();
   }
 
@@ -12,18 +14,22 @@ class MissionService {
   static Future<void> saveMissionTime(int missionNumber, TimeOfDay? time,
       {bool isUpdateTodayMission = true}) async {
     if (time != null) {
-      await MissionRepository.setMissionTime(missionNumber, time,
-          isUpdateTodayMission: isUpdateTodayMission);
+      await MissionTimeRepository.setMissionTime(missionNumber, time);
+      if (isUpdateTodayMission) {
+        await MissionRepository.updateTodayMissionTime(missionNumber, time);
+      }
     } else {
-      await MissionRepository.clearMissionTime(missionNumber,
-          isUpdateTodayMission: isUpdateTodayMission);
+      await MissionTimeRepository.clearMissionTime(missionNumber);
+      if (isUpdateTodayMission) {
+        await MissionRepository.removeTodayMission(missionNumber);
+      }
     }
     print('미션$missionNumber 시간 저장: $time');
   }
 
   // 미션 시간 불러오기
   static TimeOfDay? getMissionTime(int missionNumber) {
-    final time = MissionRepository.getMissionTime(missionNumber);
+    final time = MissionTimeRepository.getMissionTime(missionNumber);
     print('미션$missionNumber 시간 불러오기: $time');
     return time;
   }


### PR DESCRIPTION
## 개요

작업을 진행하다보니 mission_repository가 지나치게 뚱뚱해지고 있는 느낌이 들어서, "미션 시간" 관리와 "미션" 관리를 분리하려고 합니다.

## 작업사항
- [6886852](https://github.com/buku-buku/notiyou/pull/6/commits/688685242c1b8cb9bb3d63d2cf75df5376774a86) 미션 시간 데이터를 관리하는 mission_time_repository를 작성합니다.
- [f730c51](https://github.com/buku-buku/notiyou/pull/6/commits/f730c5112908e42501a4608088469b8c214657ca) 각 레포지토리에 대한 주석 설명을 추가합니다.