### PR TITLE
[feature] 미션 노티 메시지 템플릿 관련 기능을 제공하는 notification_template_service 작성

### DIFF
--- a/lib/repositories/notification_template_repository.dart
+++ b/lib/repositories/notification_template_repository.dart
@@ -16,27 +16,27 @@ class NotificationTemplateRepository {
 
   /// 성공 알림 메시지 템플릿을 조회합니다.
   static Future<String> getSuccessMessageTemplate() async {
-    if (_prefs == null) await init();
+    await init();
     return _prefs!.getString(_successMessageTemplateKey) ??
         defaultSuccessMessageTemplate;
   }
 
   /// 실패 알림 메시지 템플릿을 조회합니다.
   static Future<String> getFailureMessageTemplate() async {
-    if (_prefs == null) await init();
+    await init();
     return _prefs!.getString(_failureMessageTemplateKey) ??
         defaultFailureMessageTemplate;
   }
 
   /// 성공 알림 메시지 템플릿을 저장합니다.
   static Future<bool> setSuccessMessageTemplate(String template) async {
-    if (_prefs == null) await init();
+    await init();
     return await _prefs!.setString(_successMessageTemplateKey, template);
   }
 
   /// 실패 알림 메시지 템플릿을 저장합니다.
   static Future<bool> setFailureMessageTemplate(String template) async {
-    if (_prefs == null) await init();
+    await init();
     return await _prefs!.setString(_failureMessageTemplateKey, template);
   }
 }

--- a/lib/repositories/notification_template_repository.dart
+++ b/lib/repositories/notification_template_repository.dart
@@ -1,0 +1,42 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class NotificationTemplateRepository {
+  static SharedPreferences? _prefs;
+  static const String _successMessageTemplateKey =
+      'notification_success_message_template';
+  static const String _failureMessageTemplateKey =
+      'notification_failure_message_template';
+  static const String defaultSuccessMessageTemplate = '미션을 성공했습니다!';
+  static const String defaultFailureMessageTemplate = '미션을 실패했습니다.';
+
+  // SharedPreferences 초기화
+  static Future<void> init() async {
+    _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  /// 성공 알림 메시지 템플릿을 조회합니다.
+  static Future<String> getSuccessMessageTemplate() async {
+    if (_prefs == null) await init();
+    return _prefs!.getString(_successMessageTemplateKey) ??
+        defaultSuccessMessageTemplate;
+  }
+
+  /// 실패 알림 메시지 템플릿을 조회합니다.
+  static Future<String> getFailureMessageTemplate() async {
+    if (_prefs == null) await init();
+    return _prefs!.getString(_failureMessageTemplateKey) ??
+        defaultFailureMessageTemplate;
+  }
+
+  /// 성공 알림 메시지 템플릿을 저장합니다.
+  static Future<bool> setSuccessMessageTemplate(String template) async {
+    if (_prefs == null) await init();
+    return await _prefs!.setString(_successMessageTemplateKey, template);
+  }
+
+  /// 실패 알림 메시지 템플릿을 저장합니다.
+  static Future<bool> setFailureMessageTemplate(String template) async {
+    if (_prefs == null) await init();
+    return await _prefs!.setString(_failureMessageTemplateKey, template);
+  }
+}

--- a/lib/services/notification_template_service.dart
+++ b/lib/services/notification_template_service.dart
@@ -1,0 +1,38 @@
+import '../repositories/notification_template_repository.dart';
+
+class NotificationTemplateService {
+  static Future<String> getSuccessMessageTemplate() async {
+    return await NotificationTemplateRepository.getSuccessMessageTemplate();
+  }
+
+  static Future<String> getFailureMessageTemplate() async {
+    return await NotificationTemplateRepository.getFailureMessageTemplate();
+  }
+
+  static Future<bool> updateSuccessMessageTemplate(String newTemplate) async {
+    if (newTemplate.isEmpty) {
+      return false;
+    }
+    return await NotificationTemplateRepository.setSuccessMessageTemplate(
+        newTemplate);
+  }
+
+  static Future<bool> updateFailureMessageTemplate(String newTemplate) async {
+    if (newTemplate.isEmpty) {
+      return false;
+    }
+    return await NotificationTemplateRepository.setFailureMessageTemplate(
+        newTemplate);
+  }
+
+  static Future<bool> resetMessageTemplates() async {
+    final successReset =
+        await NotificationTemplateRepository.setSuccessMessageTemplate(
+            NotificationTemplateRepository.defaultSuccessMessageTemplate);
+    final failureReset =
+        await NotificationTemplateRepository.setFailureMessageTemplate(
+            NotificationTemplateRepository.defaultFailureMessageTemplate);
+
+    return successReset && failureReset;
+  }
+}


### PR DESCRIPTION
## 요약

미션 성공 또는 실패시 발송하게 될 메시지를 조회하고, 변경하는 기능을 제공하는 서비스 클래스를 작성합니다.

## 작업 내용

- [implement: 미션 노티 템플릿 데이터를 관리하는 notification-template_repository 작성](https://github.com/buku-buku/notiyou/pull/9/commits/fc672093460c6674f9a0bf9ca13873622c6f2c22)
- [implement: 미션 노티 메시지 템플릿에 관한 기능을 제공하는 notification_template_service 작성](https://github.com/buku-buku/notiyou/pull/9/commits/8d2e9501fdbff09339979f401b6f113279d91c86)

## 기타 사항

- 서비스 클래스는 테스트코드를 작성해두면 참 좋겠는 지점인것 같은데, repository에 대해서 의존성 주입이 가능하도록 짜여져있지 않다보니까 테스트 코드를 작성하는게 상당히 번거로운것 같더라구요. 거기다 static class처럼 구현이 되어있다보니 의존성 주입이 가능하게끔 하려면 static class를 사용하지 않게끔 다시 고쳐 구현해야할것 같습니다.
  - 약간 Flutter에는 DI Container와 같은게 존재할지 알아보고 싶은 맘이 뿜뿜한 상태..

이상 테스트 코드를 결국 작성하지 않은것에 대한 변명이었습니다 ㅎㅎ

- 이를 활용하여 #10 에서 설정 페이지에 템플릿 수정 기능을 구현하였습니다.
