### PR TITLE
[NY-41] 안드로이드 로컬 빌드 에러 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,60 @@
 # notiyou
 
-- [Dependencies](#dependencies)
+- [개발 환경 세팅](#개발-환경-세팅)
+  - [필수 요구사항](#필수-요구사항)
+  - [Java 설정](#java-설정)
+  - [수동 설정 방법 (스크립트 실패 시)](#수동-설정-방법-스크립트-실패-시)
 - [Terminology](#terminology)
 
-## Dependencies
+## 개발 환경 세팅
+
+### 필수 요구사항
+
+- Flutter SDK
+- Java 17 (will be automatically installed if not present on macOS)
+- Android Studio or VS Code
+
+### Java 설정
+
+이 프로젝트는 Android 빌드를 위해 Java 17이 필요합니다. 자동 설정을 위한 스크립트를 제공합니다:
 
 ```sh
-flutter pub add go_router
+# 스크립트 실행 권한 부여 (최초 1회)
+chmod +x setup-android-local-properties.sh
+
+# 설정 스크립트 실행
+./setup-android-local-properties.sh
 ```
+
+스크립트는 다음 작업을 수행합니다:
+
+1. Java 17 설치 여부 확인
+2. 설치되어 있지 않은 경우 Homebrew를 통해 설치 (macOS만 해당)
+3. `android/local.properties`에 올바른 Java 경로 설정
+
+### 수동 설정 방법 (스크립트 실패 시)
+
+스크립트가 동작하지 않을 경우 수동으로 설정할 수 있습니다:
+
+1. Java 17 설치:
+
+   ```bash
+   # macOS
+   brew install openjdk@17
+
+   # Linux
+   sudo apt install openjdk-17-jdk
+   ```
+
+2. `android/local.properties`에 Java 경로 추가:
+
+   ```properties
+   # macOS의 경우
+   org.gradle.java.home=/path/to/your/java-17
+
+   # macOS에서 Java 17 경로 확인 방법:
+   /usr/libexec/java_home -v 17
+   ```
 
 ## Terminology
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,7 @@
 # notiyou
 
-- [Setup history](#setup-history)
 - [Dependencies](#dependencies)
-
-## Setup history
-
-```sh
-# 빈 프로젝트 생성
-flutter create -e notiyou
-```
-
-```sh
-The configured version of Java detected may conflict with the Gradle version in your new Flutter app.
-
-[RECOMMENDED] If so, to keep the default Gradle version 8.3, make
-sure to download a compatible Java version
-(Java 17 <= compatible Java version < Java 21).
-You may configure this compatible Java version by running:
-`flutter config --jdk-dir=<JDK_DIRECTORY>`
-Note that this is a global configuration for Flutter.
-
-
-Alternatively, to continue using your configured Java version, update the Gradle
-version specified in the following file to a compatible Gradle version (compatible Gradle version
-range: 8.4 - 8.7):
-/Users/cheo/Works/buku-buku/notiyou/android/gradle/wrapper/gradle-wrapper.properties
-
-You may also update the Gradle version used by running
-`./gradlew wrapper --gradle-version=<COMPATIBLE_GRADLE_VERSION>`.
-```
-
-```sh
-# java 17 버전으로 변경
-java-17
-```
-
-```sh
-# gradle 버전 업데이트
-./gradlew wrapper --gradle-version=8.4
-```
+- [Terminology](#terminology)
 
 ## Dependencies
 

--- a/history.md
+++ b/history.md
@@ -1,0 +1,40 @@
+# History
+
+- [Setup history](#setup-history)
+
+## Setup history
+
+```sh
+# 빈 프로젝트 생성
+flutter create -e notiyou
+```
+
+```sh
+The configured version of Java detected may conflict with the Gradle version in your new Flutter app.
+
+[RECOMMENDED] If so, to keep the default Gradle version 8.3, make
+sure to download a compatible Java version
+(Java 17 <= compatible Java version < Java 21).
+You may configure this compatible Java version by running:
+`flutter config --jdk-dir=<JDK_DIRECTORY>`
+Note that this is a global configuration for Flutter.
+
+
+Alternatively, to continue using your configured Java version, update the Gradle
+version specified in the following file to a compatible Gradle version (compatible Gradle version
+range: 8.4 - 8.7):
+/Users/cheo/Works/buku-buku/notiyou/android/gradle/wrapper/gradle-wrapper.properties
+
+You may also update the Gradle version used by running
+`./gradlew wrapper --gradle-version=<COMPATIBLE_GRADLE_VERSION>`.
+```
+
+```sh
+# java 17 버전으로 변경
+java-17
+```
+
+```sh
+# gradle 버전 업데이트
+./gradlew wrapper --gradle-version=8.4
+```

--- a/setup-android-local-properties.sh
+++ b/setup-android-local-properties.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# 색상 정의
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+STRESS=${YELLOW}
+INDENT="  "
+
+echo_red() {
+  echo -e "\n${RED}$1${NC}"
+}
+
+echo_green() {
+  echo -e "\n${GREEN}$1${NC}"
+}
+
+echo_yellow() {
+  echo -e "\n${YELLOW}$1${NC}"
+}
+
+echo_cyan() {
+  echo -e "\n${CYAN}$1${NC}"
+}
+
+echo_blue() {
+  echo -e "\n${BLUE}$1${NC}"
+}
+
+# 에러 처리
+set -e
+
+# Java 17 확인
+echo ""
+JAVA_17_PATH=$(/usr/libexec/java_home -v 17 2>/dev/null || true)
+if [ -z "$JAVA_17_PATH" ]; then
+    echo_red "Java 17 not found"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo_yellow "Installing Java 17 via Homebrew..."
+        brew install openjdk@17
+        JAVA_17_PATH=$(/usr/libexec/java_home -v 17)
+    else
+        echo_red "Please install Java 17 manually"
+        exit 1
+    fi
+else
+    echo -e "Java 17 found at \n${INDENT}${STRESS}$JAVA_17_PATH${NC}"
+fi
+
+# local.properties 파일 경로
+PROPERTIES_FILE="android/local.properties"
+
+# 기존 파일이 있다면 Java 설정 제거
+if [ -f "$PROPERTIES_FILE" ]; then
+    sed -i '' '/^org\.gradle\.java\.home=/d' "$PROPERTIES_FILE"
+    
+    # 파일 끝에 빈 줄이 없다면 추가
+    if [[ -s "$PROPERTIES_FILE" && $(tail -c1 "$PROPERTIES_FILE" | wc -l) -eq 0 ]]; then
+        echo "" >> "$PROPERTIES_FILE"
+    fi
+fi
+
+# Java 설정 추가
+echo ""
+echo "org.gradle.java.home=${JAVA_17_PATH}" >> "$PROPERTIES_FILE"
+echo -e "$PROPERTIES_FILE updated \n${INDENT}${STRESS}org.grade.java.home=${JAVA_17_PATH}${NC}"
+
+# 프로젝트 클린
+echo ""
+echo -e "Project clean up\n"
+flutter clean
+cd android && ./gradlew clean
+cd ..
+flutter pub get
+
+echo_green "✅ Setup complete!"


### PR DESCRIPTION
> [!Note]
>
> #23 CI는 성공하는데 로컬 환경에서만 android 빌드가 실패하는 이유
>
> 트러블 슈팅 과정을 기록했습니다. 

## 요약

현재 메인브랜치에서 안드로이드 로컬 빌드를 하면 발생하는 에러를 해결합니다.

## 작업 내용

- [chore: README 문서 정리](https://github.com/buku-buku/notiyou/pull/22/commits/31bf02c4bc48fc7f362a8747db314b9405162088)
- [fix: android 빌드에 필요한 jav 버전의 local 환경 세팅 기능 추가](https://github.com/buku-buku/notiyou/pull/22/commits/9090751d0bd5793f842c281b708f09bd9f28ca69)


## 기타 사항

원인 추적

- CI에서는 안드로이드 빌드가 잘 동작하고 로컬에서는 잘 안됩니다.
- 그래서 CI 환경과 제 로컬 환경의 차이점을 살펴봤더니 다음과 같았습니다:
  - CI 환경: java 17 버전 사용 중
  - 로컬 환경: java 21 버전 사용 중 (`flutter doctor -v` 명령어로 확인해본 결과 현재 flutter 프로젝트의 android toolchain에 java 버전이 21을 쓰고 있었습니다)

<img width="623" alt="image" src="https://github.com/user-attachments/assets/4646288d-418c-4821-a21f-4f388ef7eca0">

해결 과정

- `android/gradle.properties`에 로컬에 설치된 java 17 경로를 매핑해주니까 빌드가 성공합니다 
  ```java
  org.gradle.java.home=/opt/homebrew/Cellar/openjdk@17/17.0.13/libexec/openjdk.jdk/Contents/Home
  ```
- 하지만 `android/gradle.properties`는 CI뿐만 아니라 프로덕션 빌드에서도 사용해야 하므로 특정 로컬의 절대경로를 넣는 것은 부적절합니다. 
- 찾아보니 `.env.local`처럼 로컬에서의 properties 를 주입하는 `android/local.properties`가 있더라고요. 그래서 각자의 로컬환경에 맞게 `android/local.properties`에 java 17 경로를 매핑하는 shell script를 추가합니다. (설명은 README에 적어두었습니다)

## 체크리스트

- 각자 로컬환경에서 되는지 확인
  - [x] 민철
  - [ ] 사휘: `gradle.properties`에 넣으면 되는데 `local.properties`에는 넣어도 동작 안 한다.
  - [ ] 정희
  - [ ] 무호: `gradle.properties`에 넣으면 되는데 `local.properties`에는 넣어도 동작 안 한다.

