### PR TITLE
[NY-38] feat: supabase 카카오 로그인 연동

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     }
   },
   "dart.previewFlutterUiGuides": true,
-  "dart.previewFlutterUiGuidesCustomTracking": true
+  "dart.previewFlutterUiGuidesCustomTracking": true,
+  "cSpell.words": ["Kakao", "notiyou"]
 }

--- a/lib/screens/splash_page.dart
+++ b/lib/screens/splash_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:kakao_flutter_sdk/kakao_flutter_sdk_user.dart';
+import 'package:notiyou/screens/config_page.dart';
+import 'package:notiyou/screens/signup_page.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
 
 import 'home_page.dart';
 import 'login_page.dart';
@@ -23,8 +25,21 @@ class _SplashPageState extends State<SplashPage> {
 
   Future<void> _checkLoginStatus() async {
     try {
-      await UserApi.instance.me();
-      if (mounted) {
+      final user = await AuthService.getUser();
+      if (user == null) {
+        throw Exception('User not found');
+      }
+
+      final registrationStatus = AuthService.getRegistrationStatus(user);
+      if (!mounted) {
+        return;
+      }
+
+      if (registrationStatus['invitation_code'] != true) {
+        context.go(SignupPage.routeName);
+      } else if (registrationStatus['mission_setting'] != true) {
+        context.go(ConfigPage.onboardingRouteName);
+      } else {
         context.go(HomePage.routeName);
       }
     } catch (error) {

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -1,0 +1,50 @@
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk_talk.dart';
+import 'package:notiyou/services/auth/kakao_auth_service.dart';
+import 'package:notiyou/services/auth/supabase_auth_service.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+// TODO: 자체 User 객체 생성 및 관리 필요.
+class AuthService {
+  static Future<supabase.User?> loginWithKakao() async {
+    // * 기존 로그인 상태 초기화
+    if (await isLoggedIn()) {
+      await logout();
+    }
+
+    final OAuthToken? token = await KakaoAuthService.login();
+
+    if (token == null) {
+      throw Exception('카카오 로그인에 실패하였습니다.');
+    }
+
+    KakaoAuthService.validateTokenForSupabaseLink(token);
+    return await SupabaseAuthService.signInWithKakaoToken(token.idToken!);
+  }
+
+  static Future<void> logout() async {
+    await KakaoAuthService.logout();
+    await SupabaseAuthService.signOut();
+  }
+
+  static Future<bool> isLoggedIn() async {
+    try {
+      final user = await getUser();
+      return user != null;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  static Future<supabase.User?> getUser() async {
+    return await SupabaseAuthService.getUser();
+  }
+
+  static bool isRegistrationCompleted(supabase.User user) {
+    return SupabaseAuthService.isRegistrationCompleted(user);
+  }
+
+// TODO: RegistrationStatus 객체 정의
+  static Map<String, bool> getRegistrationStatus(supabase.User user) {
+    return SupabaseAuthService.getRegistrationStatus(user);
+  }
+}

--- a/lib/services/auth/kakao_auth_service.dart
+++ b/lib/services/auth/kakao_auth_service.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/services.dart';
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk_talk.dart' as kakao;
+
+class KakaoAuthService {
+  static final _kakaoUserApi = kakao.UserApi.instance;
+
+  static Future<bool> isKakaoTalkInstalled() async {
+    return await kakao.isKakaoTalkInstalled();
+  }
+
+  static Future<kakao.OAuthToken?> _loginWithKakaoTalk() async {
+    try {
+      return await _kakaoUserApi.loginWithKakaoTalk();
+    } on PlatformException catch (error) {
+      if (error.code == 'CANCELED') {
+        return null;
+      }
+
+      return await _loginWithKakaoAccount();
+    }
+  }
+
+  static Future<kakao.OAuthToken?> _loginWithKakaoAccount() async {
+    try {
+      return await _kakaoUserApi.loginWithKakaoAccount();
+    } catch (error) {
+      return null;
+    }
+  }
+
+  static Future<kakao.OAuthToken?> login() async {
+    return await isKakaoTalkInstalled()
+        ? _loginWithKakaoTalk()
+        : _loginWithKakaoAccount();
+  }
+
+  static void validateTokenForSupabaseLink(kakao.OAuthToken token) {
+    final userIdToken = token.idToken;
+    if (userIdToken == null) {
+      throw Exception(
+          '카카오 ID 토큰 발급에 실패하였습니다. 카카오의 OpenID Connect 활성화 여부 및 scope에 openid가 포함되었는지 확인하세요.');
+    }
+  }
+
+  static Future<void> logout() async {
+    await _kakaoUserApi.logout();
+  }
+}

--- a/lib/services/auth/supabase_auth_service.dart
+++ b/lib/services/auth/supabase_auth_service.dart
@@ -1,0 +1,41 @@
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+import 'package:notiyou/services/supabase_service.dart';
+
+class SupabaseAuthService {
+  static Future<supabase.User?> signInWithKakaoToken(String idToken) async {
+    final authResponse = await SupabaseService.client.auth.signInWithIdToken(
+      provider: supabase.OAuthProvider.kakao,
+      idToken: idToken,
+    );
+    return authResponse.user;
+  }
+
+  static Future<void> signOut() async {
+    await SupabaseService.client.auth.signOut();
+  }
+
+  static Future<supabase.User?> getUser() async {
+    final response = await SupabaseService.client.auth.getUser();
+    return response.user;
+  }
+
+  static bool isRegistrationCompleted(supabase.User user) {
+    final registrationStatus = getRegistrationStatus(user);
+    return registrationStatus['invitation_code'] == true &&
+        registrationStatus['mission_setting'] == true;
+  }
+
+  static Map<String, bool> getRegistrationStatus(supabase.User user) {
+    if (user.userMetadata == null) {
+      return {
+        'invitation_code': false,
+        'mission_setting': false,
+      };
+    }
+    // * 초대코드 및 미션 설정까지 입력 받아야 회원가입이 완료되었다고 판단할 수 있음
+    return {
+      'invitation_code': user.userMetadata!['invitation_code'] != null,
+      'mission_setting': user.userMetadata!['mission_setting'] != null,
+    };
+  }
+}

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -15,9 +15,4 @@ class SupabaseService {
     );
     _client = Supabase.instance.client;
   }
-
-  @Deprecated('요청 테스트용으로 작성된 메서드로, 이후 기능 개발 시 삭제 예정')
-  static Future<PostgrestList> test() async {
-    return await _client.from('test').select('*');
-  }
 }


### PR DESCRIPTION
## 요약

kakao SDK를 통해 OAuth 인증을 수행하고, 이를 supabase 유저 테이블에 등록하도록 구현하였습니다.

*인증의 플로우를 그림으로 표현해보았습니다.

<img width="480" alt="image" src="https://github.com/user-attachments/assets/7e10909b-99ca-4bb2-9dc0-35a9f3491f5e">

## 작업 내용

- [feat: supabase 카카오 로그인 연동](https://github.com/buku-buku/notiyou/pull/25/commits/9650a94cb7a8d2037598a37961ed3fba9a30d351)

## 기타 사항

- `New` auth_service.dart, kakao_auth_service.dart, supabase_auth_service.dart
기존의 인증 처리를 하는데 있어서 kakao <-> supabase 간의 연동으로 인한 복잡도가 생김에 따라, 기존 login_page와 splash_page에 구현되어 있었던 비즈니스 로직을 auth_service 클래스로 추출하였습니다. 또한, kakao와 supabase에 대한 로직을 분리하여 관리하기 위해 kakao_auth_service, supabase_auth_service 라는 클래스로 분리하여 관리하도록 했습니다. 

- 코드 구현 이외에 설정한 과정 기록을 [노션 페이지](https://www.notion.so/SDK-Supabase-bb9db4247879435eba97cdf9dbab05a7?pvs=4)에 정리해 두었습니다.

## 체크리스트

플랫폼 별 테스트
- [x] Android
- [x] IOS 

해당 브랜치에서 앱을 실행하여, 각자의 카카오 로그인을 수행하고, [supabase의 auth 테이블](https://supabase.com/dashboard/project/pmiivbdkefsnzznxghwb/auth/users)에 잘 등록이 되는지 확인해 주세요.

- [x] 무호
- [ ] 사휘
- [ ] 정희
- [ ] 민철


## 스크린샷

![image](https://github.com/user-attachments/assets/9bb184c3-ff36-4c61-8b5d-f16a0378aa6b)
