### PR TITLE
[NY-14] 히스토리 페이지에 미션 기록 목록 추가

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     android:label="notiyou"
     android:name="${applicationName}"
     android:icon="@mipmap/ic_launcher"
+    android:enableOnBackInvokedCallback="true"
   >
     <activity
       android:name=".MainActivity"

--- a/lib/fixtures/mission_history.dart
+++ b/lib/fixtures/mission_history.dart
@@ -1,0 +1,35 @@
+// 🚨 fixtures 폴더는 supabase에서 데이터를 가져오는 것이 완성되면 삭제합니다. 개발 편의를 위해 작성된 임시 데이터입니다.
+
+import '../models/mission_history.dart';
+
+final baseDate = DateTime.parse('2024-11-22 13:00:00');
+const missionCountOnDay = 2;
+const missionInterval = (12 ~/ missionCountOnDay);
+
+List<MissionHistory> moreData = List.generate(
+  12,
+  (index) {
+    final dayDelta = index ~/ missionCountOnDay;
+
+    final missionTime = baseDate.add(
+      Duration(
+        days: dayDelta,
+        hours: (index % missionCountOnDay) * missionInterval,
+      ),
+    );
+    final doneTime = missionTime.add(const Duration(minutes: -3));
+    final createTime = doneTime.add(const Duration(minutes: -3));
+
+    return (
+      id: index + 1,
+      missionId: index + 1,
+      missionAt: missionTime.toString(),
+      doneAt: index.isEven ? doneTime.toString() : null,
+      createdAt: createTime.toString(),
+    );
+  },
+);
+
+List<MissionHistory> missionHistoriesFixture = [
+  ...moreData,
+];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_talk.dart';
+import 'package:intl/date_symbol_data_local.dart';
 
 import 'package:notiyou/services/dotenv_service.dart';
 import 'package:notiyou/services/supabase_service.dart';
@@ -10,6 +11,7 @@ import 'services/push_alarm_service.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await DotEnvService.init();
+  await initializeDateFormatting('ko_KR', null);
 
   KakaoSdk.init(
     nativeAppKey: DotEnvService.getValue('KAKAO_NATIVE_APP_KEY'),

--- a/lib/models/mission_history.dart
+++ b/lib/models/mission_history.dart
@@ -1,0 +1,7 @@
+typedef MissionHistory = ({
+  int id,
+  int missionId,
+  String missionAt,
+  String? doneAt,
+  String createdAt,
+});

--- a/lib/screens/history_page.dart
+++ b/lib/screens/history_page.dart
@@ -1,17 +1,104 @@
 import 'package:flutter/material.dart';
+import '../utils/time_utils.dart';
+import '../widgets/mission_history_list_item.dart';
+import '../fixtures/mission_history.dart';
+import '../models/mission_history.dart';
 
-class HistoryPage extends StatelessWidget {
+class HistoryPage extends StatefulWidget {
   const HistoryPage({super.key});
 
   static const String routeName = '/history';
 
   @override
+  State<HistoryPage> createState() => _HistoryPageState();
+}
+
+class _HistoryPageState extends State<HistoryPage> {
+  Map<String, List<MissionHistory>> groupedMissionHistories = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMissionHistories();
+  }
+
+  Future<void> _loadMissionHistories() async {
+    var missionHistories = missionHistoriesFixture;
+
+    setState(() {
+      groupedMissionHistories = _groupMissionHistoriesByDate(missionHistories);
+    });
+  }
+
+  Map<String, List<MissionHistory>> _groupMissionHistoriesByDate(
+      List<MissionHistory> missionHistories) {
+    final Map<String, List<MissionHistory>> groupedMissionHistories = {};
+
+    for (var history in missionHistories) {
+      final dateKey = TimeUtils.formatDateTime(
+        date: DateTime.parse(history.missionAt),
+        format: 'yyyy-MM-dd (E)',
+      );
+
+      if (groupedMissionHistories.containsKey(dateKey)) {
+        groupedMissionHistories[dateKey]!.add(history);
+      } else {
+        groupedMissionHistories[dateKey] = [history];
+      }
+    }
+    return groupedMissionHistories;
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('History')),
-      body: const Center(
-        child: Text('캘린더 UI - 미션 완수 현황'),
+      appBar: AppBar(title: const Text('히스토리')),
+      body: groupedMissionHistories.isEmpty
+          ? const Center(child: Text('미션 히스토리가 없습니다.'))
+          : ListView.builder(
+              itemCount: groupedMissionHistories.keys.length,
+              itemBuilder: (context, index) {
+                final dateKey = groupedMissionHistories.keys.elementAt(index);
+                final histories = groupedMissionHistories[dateKey]!;
+
+                return StyledGroup(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        dateKey,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      ...histories.map((history) =>
+                          MissionHistoryListItem(missionHistory: history)),
+                    ],
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}
+
+class StyledGroup extends StatelessWidget {
+  final Widget child;
+
+  const StyledGroup({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        border: const Border(
+          bottom: BorderSide(
+            color: Colors.grey,
+            width: 0.4,
+          ),
+        ),
       ),
+      child: child,
     );
   }
 }

--- a/lib/screens/history_page.dart
+++ b/lib/screens/history_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import '../utils/time_utils.dart';
 import '../widgets/mission_history_list_item.dart';
-import '../fixtures/mission_history.dart';
 import '../models/mission_history.dart';
+import '../services/mission_history_service.dart';
 
 class HistoryPage extends StatefulWidget {
   const HistoryPage({super.key});
@@ -23,7 +23,9 @@ class _HistoryPageState extends State<HistoryPage> {
   }
 
   Future<void> _loadMissionHistories() async {
-    var missionHistories = missionHistoriesFixture;
+    // TODO(민철): 아래 더미 데이터를 MissionHistoryService에서 사용할 수 있는 실제 유저 아이디로 변경해야 합니다.
+    var missionHistories =
+        await MissionHistoryService.getMissionHistoriesByUserId('1234');
 
     setState(() {
       groupedMissionHistories = _groupMissionHistoriesByDate(missionHistories);

--- a/lib/services/mission_history_service.dart
+++ b/lib/services/mission_history_service.dart
@@ -1,0 +1,9 @@
+import '../models/mission_history.dart';
+import '../fixtures/mission_history.dart';
+
+class MissionHistoryService {
+  static Future<List<MissionHistory>> getMissionHistoriesByUserId(
+      String userId) async {
+    return missionHistoriesFixture;
+  }
+}

--- a/lib/utils/time_utils.dart
+++ b/lib/utils/time_utils.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class TimeUtils {
   // 시간 객체를 문자열로 변환
@@ -30,5 +31,12 @@ class TimeUtils {
   /// 년월일만 포함하는 날짜 문자열 생성
   static String stringifyYearMonthDay(DateTime date) {
     return DateTime(date.year, date.month, date.day).toIso8601String();
+  }
+
+  static String formatDateTime({
+    required DateTime date,
+    required String format,
+  }) {
+    return DateFormat(format, 'ko_KR').format(date);
   }
 }

--- a/lib/widgets/mission_history_list_item.dart
+++ b/lib/widgets/mission_history_list_item.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import '../models/mission_history.dart';
+
+const incompleteText = '미완료';
+const done = (color: Colors.green, icon: Icons.check_circle);
+const notDone = (color: Colors.red, icon: Icons.cancel);
+
+class MissionHistoryListItem extends StatelessWidget {
+  final MissionHistory missionHistory;
+
+  const MissionHistoryListItem({super.key, required this.missionHistory});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDone = missionHistory.doneAt != null;
+    final doneAtText = isDone
+        ? TimeOfDay.fromDateTime(DateTime.parse(missionHistory.doneAt!))
+            .format(context)
+        : incompleteText;
+
+    final missionAtText =
+        TimeOfDay.fromDateTime(DateTime.parse(missionHistory.missionAt))
+            .format(context);
+
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      title: Text('미션 ${missionHistory.missionId}'),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.access_time, size: 16),
+              const SizedBox(width: 4),
+              Text('설정 시간: $missionAtText'),
+            ],
+          ),
+          Row(
+            children: [
+              const Icon(Icons.check_circle_outline, size: 16),
+              const SizedBox(width: 4),
+              Text('완료 시간: $doneAtText'),
+            ],
+          ),
+        ],
+      ),
+      trailing: Icon(
+        isDone ? done.icon : notDone.icon,
+        color: isDone ? done.color : notDone.color,
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -264,6 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.0"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_local_notifications: ^18.0.1
   timezone: ^0.9.2
   supabase_flutter: ^2.8.0
+  intl: ^0.17.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 요약

사용자는 히스토리 페이지에 들어가면 미션 기록 목록을 볼 수 있습니다. (Supabase와의 기능 연동은 되어 있지 않고 UI만 추가한 변경)

> [!Warning]
>
> 개발 편의를 위해 미션 기록은 더미 데이터를 fixture로 넣어서 보여줍니다. 따라서 현재 PR에서는 홈에서 미션을 체크해도 히스토리 페이지에 반영되지 않습니다.

## 작업 내용

- [chore: android 워닝 제거](https://github.com/buku-buku/notiyou/pull/27/commits/c9b0736b77aca577c09a0cc9739aba90e96e7372)
- [chore: 한국 local 시간 계산을 위해 Intl 패키지 추가](https://github.com/buku-buku/notiyou/pull/27/commits/9d417a1733a4229d8361138488d4897333a75aad)
- [chore: MissionHistory 모델 및 fixture 추가](https://github.com/buku-buku/notiyou/pull/27/commits/2d180c84bc626fec46ece8948176175227957c64)
- [feat: HistoryPage에서 MissionHistory 목록 렌더링](https://github.com/buku-buku/notiyou/pull/27/commits/5a392e34c70a3e2d49e7ecb8d9e344783f7c2a8f)
- [feat: history_page에서 MissionHistoryService와 소통하도록 변경](https://github.com/buku-buku/notiyou/pull/27/commits/9f7d505600cc039db7024b5fa626309478f2cee0)

## 스크린샷

<img width="525" alt="image" src="https://github.com/user-attachments/assets/052204f8-4927-45ed-bc2c-2b0da41e6415">
