### PR TITLE
[NY-39] mission_time_repository Supabase 연동하기

### DIFF
--- a/lib/repositories/mission_time_repository_interface.dart
+++ b/lib/repositories/mission_time_repository_interface.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+abstract interface class MissionTimeRepository {
+  Future<void> init();
+  Future<TimeOfDay?> getMissionTime(int missionNumber);
+  Future<void> setMissionTime(int missionNumber, TimeOfDay time);
+  Future<void> clearMissionTime(int missionNumber);
+}

--- a/lib/repositories/mission_time_repository_local.dart
+++ b/lib/repositories/mission_time_repository_local.dart
@@ -1,24 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../utils/time_utils.dart';
 
 /// 미션 시간 데이터를 관리하는 저장소입니다.
 ///
+///
 /// 설정된 미션 시간은 서버에 기록되며, 서버에서 미션을 생성할때 사용됩니다.
 ///
 /// 다만 인터넷 연결이 불안정한 환경을 대비하여, 로컬에도 미션 시간을 저장합니다.
 /// 해당 값을 통해 로컬상에서 미션이 생성될 수 있습니다.
-class MissionTimeRepository {
-  static SharedPreferences? _prefs;
+///
+/// ⚠️ 현재 사용되지 않는 저장소입니다. 필요가 있기 전까지는 MissionTimeRepositoryRemote를 사용해주세요.
+class MissionTimeRepositoryLocal implements MissionTimeRepository {
+  SharedPreferences? _prefs;
 
-  static Future<void> init() async {
+  @override
+  Future<void> init() async {
     _prefs ??= await SharedPreferences.getInstance();
   }
 
-  static String _getMissionKey(int missionNumber) => 'mission$missionNumber';
+  String _getMissionKey(int missionNumber) => 'mission$missionNumber';
 
   // 미션 시간 조회
-  static TimeOfDay? getMissionTime(int missionNumber) {
+  @override
+  Future<TimeOfDay?> getMissionTime(int missionNumber) async {
+    await init();
     final key = _getMissionKey(missionNumber);
     final timeStr = _prefs!.getString(key);
 
@@ -28,13 +35,17 @@ class MissionTimeRepository {
   }
 
   // 미션 시간 설정
-  static Future<void> setMissionTime(int missionNumber, TimeOfDay time) async {
+  @override
+  Future<void> setMissionTime(int missionNumber, TimeOfDay time) async {
+    await init();
     final key = _getMissionKey(missionNumber);
     await _prefs!.setString(key, TimeUtils.stringifyTime(time));
   }
 
   // 미션 시간 초기화
-  static Future<void> clearMissionTime(int missionNumber) async {
+  @override
+  Future<void> clearMissionTime(int missionNumber) async {
+    await init();
     final key = _getMissionKey(missionNumber);
     await _prefs!.remove(key);
   }

--- a/lib/repositories/mission_time_repository_remote.dart
+++ b/lib/repositories/mission_time_repository_remote.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:notiyou/repositories/mission_time_repository_interface.dart';
+import 'package:notiyou/services/supabase_service.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../utils/time_utils.dart';
+
+/// 미션 시간 데이터를 관리하는 저장소입니다.
+///
+/// 설정된 미션 시간은 서버에 기록되며, 서버에서 미션을 생성할때 사용됩니다.
+///
+class MissionTimeRepositoryRemote implements MissionTimeRepository {
+  // 싱글턴 인스턴스
+  static final MissionTimeRepositoryRemote _instance =
+      MissionTimeRepositoryRemote._internal();
+
+  // 팩토리 생성자
+  factory MissionTimeRepositoryRemote() {
+    return _instance;
+  }
+
+  // private 생성자
+  MissionTimeRepositoryRemote._internal();
+
+  static final supabaseClient = SupabaseService.client;
+
+  @override
+  Future<void> init() async {}
+
+  // 미션 시간 조회
+  @override
+  Future<TimeOfDay?> getMissionTime(int missionNumber) async {
+    final userId = supabaseClient.auth.currentUser?.id;
+    if (userId == null) {
+      throw const AuthException('User not found');
+    }
+
+    final mission = await supabaseClient
+        .from('missions')
+        .select('mission_at')
+        .eq('user_id', userId)
+        .eq('mission_number', missionNumber);
+
+    return mission.isNotEmpty
+        ? TimeUtils.parseTime(mission.first['mission_at'])
+        : null;
+  }
+
+  // 미션 시간 설정
+  @override
+  Future<void> setMissionTime(int missionNumber, TimeOfDay time) async {
+    final userId = supabaseClient.auth.currentUser?.id;
+    if (userId == null) {
+      throw const AuthException('User not found');
+    }
+    final hasMission = await supabaseClient
+        .from('missions')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('mission_number', missionNumber);
+
+    if (hasMission.isNotEmpty) {
+      await supabaseClient
+          .from('missions')
+          .update({'mission_at': TimeUtils.stringifyTime(time)})
+          .eq('user_id', userId)
+          .eq('mission_number', missionNumber);
+    } else {
+      await supabaseClient.from('missions').insert({
+        'user_id': userId,
+        'mission_number': missionNumber,
+        'mission_at': TimeUtils.stringifyTime(time),
+      });
+    }
+  }
+
+  // 미션 시간 초기화
+  @override
+  Future<void> clearMissionTime(int missionNumber) async {
+    final userId = supabaseClient.auth.currentUser?.id;
+    if (userId == null) {
+      throw const AuthException('User not found');
+    }
+    await supabaseClient
+        .from('missions')
+        .delete()
+        .eq('user_id', userId)
+        .eq('mission_number', missionNumber);
+  }
+}

--- a/lib/screens/config_page.dart
+++ b/lib/screens/config_page.dart
@@ -28,17 +28,23 @@ class _ConfigPageState extends State<ConfigPage> {
   }
 
   Future<void> _loadSavedTimes() async {
+    final results = await Future.wait([
+      MissionService.getMissionTime(1),
+      MissionService.getMissionTime(2),
+    ]);
     setState(() {
-      _mission1Time = MissionService.getMissionTime(1);
-      _mission2Time = MissionService.getMissionTime(2);
+      // 병렬 처리
+
+      _mission1Time = results[0];
+      _mission2Time = results[1];
     });
   }
 
   Future<void> _saveTimes() async {
     // 시간이 변경되었는지 확인
     final bool hasTimeChanged =
-        _mission1Time != MissionService.getMissionTime(1) ||
-            _mission2Time != MissionService.getMissionTime(2);
+        _mission1Time != await MissionService.getMissionTime(1) ||
+            _mission2Time != await MissionService.getMissionTime(2);
 
     final hasTodayMissions = await MissionService.hasTodayMissions();
 

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:notiyou/repositories/mission_time_repository_interface.dart';
+import 'package:notiyou/repositories/mission_time_repository_local.dart';
 import 'package:notiyou/repositories/mission_time_repository_remote.dart';
 import '../models/mission.dart';
 import '../repositories/mission_repository.dart';
 import '../services/push_alarm_service.dart';
 
 class MissionService {
-  static final MissionTimeRepository _missionTimeRepository =
+  static MissionTimeRepository _missionTimeRepository =
       MissionTimeRepositoryRemote();
 
   // SharedPreferences 초기화
@@ -86,5 +87,9 @@ class MissionService {
   static Future<void> clearAllMissionData() async {
     await MissionRepository.clearAllMissions();
     await PushAlarmService.cancelAllMissionPushAlarms();
+  }
+
+  static switchToLocalRepository() {
+    _missionTimeRepository = MissionTimeRepositoryLocal();
   }
 }

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:notiyou/repositories/mission_time_repository_interface.dart';
+import 'package:notiyou/repositories/mission_time_repository_remote.dart';
 import '../models/mission.dart';
-import '../repositories/mission_time_repository.dart';
 import '../repositories/mission_repository.dart';
 import '../services/push_alarm_service.dart';
 
 class MissionService {
+  static final MissionTimeRepository _missionTimeRepository =
+      MissionTimeRepositoryRemote();
+
   // SharedPreferences 초기화
   static Future<void> init() async {
-    await MissionTimeRepository.init();
+    await _missionTimeRepository.init();
     await MissionRepository.init();
   }
 
@@ -15,12 +19,12 @@ class MissionService {
   static Future<void> saveMissionTime(int missionNumber, TimeOfDay? time,
       {bool isUpdateTodayMission = true}) async {
     if (time != null) {
-      await MissionTimeRepository.setMissionTime(missionNumber, time);
+      await _missionTimeRepository.setMissionTime(missionNumber, time);
       if (isUpdateTodayMission) {
         await MissionRepository.updateTodayMissionTime(missionNumber, time);
       }
     } else {
-      await MissionTimeRepository.clearMissionTime(missionNumber);
+      await _missionTimeRepository.clearMissionTime(missionNumber);
       if (isUpdateTodayMission) {
         await MissionRepository.removeTodayMission(missionNumber);
       }
@@ -30,8 +34,8 @@ class MissionService {
   }
 
   // 미션 시간 불러오기
-  static TimeOfDay? getMissionTime(int missionNumber) {
-    final time = MissionTimeRepository.getMissionTime(missionNumber);
+  static Future<TimeOfDay?> getMissionTime(int missionNumber) async {
+    final time = await _missionTimeRepository.getMissionTime(missionNumber);
 
     return time;
   }

--- a/lib/services/push_alarm_service.dart
+++ b/lib/services/push_alarm_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:notiyou/repositories/mission_time_repository.dart';
+import 'package:notiyou/repositories/mission_time_repository_interface.dart';
+import 'package:notiyou/repositories/mission_time_repository_remote.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:timezone/timezone.dart' as tz;
@@ -9,6 +10,9 @@ import 'package:timezone/data/latest.dart' as tz;
 import '../routes/router.dart';
 
 class PushAlarmService {
+  static final MissionTimeRepository _missionTimeRepository =
+      MissionTimeRepositoryRemote();
+
   static final FlutterLocalNotificationsPlugin _pushAlarms =
       FlutterLocalNotificationsPlugin();
 
@@ -65,8 +69,8 @@ class PushAlarmService {
   }
 
   static Future<void> _scheduleDevicePushAlarms() async {
-    final firstMissionTime = MissionTimeRepository.getMissionTime(1);
-    final secondMissionTime = MissionTimeRepository.getMissionTime(2);
+    final firstMissionTime = await _missionTimeRepository.getMissionTime(1);
+    final secondMissionTime = await _missionTimeRepository.getMissionTime(2);
 
     if (firstMissionTime != null) {
       await scheduleMissionPushAlarm(1, firstMissionTime);

--- a/lib/services/push_alarm_service.dart
+++ b/lib/services/push_alarm_service.dart
@@ -3,6 +3,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:notiyou/repositories/mission_time_repository_remote.dart';
 import 'package:notiyou/screens/home_page.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:timezone/timezone.dart' as tz;
 import 'package:timezone/data/latest.dart' as tz;
@@ -68,7 +69,11 @@ class PushAlarmService {
         );
   }
 
+  // TODO: 로그인 및 회원가입을 모두 마친 후, 미션 시간을 설정한 후에 알림 설정을 하도록 수정
   static Future<void> _scheduleDevicePushAlarms() async {
+    if (!await AuthService.isLoggedIn()) {
+      return;
+    }
     final firstMissionTime = await _missionTimeRepository.getMissionTime(1);
     final secondMissionTime = await _missionTimeRepository.getMissionTime(2);
 

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -15,4 +15,8 @@ class SupabaseService {
     );
     _client = Supabase.instance.client;
   }
+
+  static setMockClient(SupabaseClient mockClient) {
+    _client = mockClient;
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -440,6 +440,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^4.0.0
+  mocktail: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/test/screens/signup_page_test.dart
+++ b/test/screens/signup_page_test.dart
@@ -4,14 +4,25 @@ import 'package:go_router/go_router.dart';
 import 'package:notiyou/screens/signup_page.dart';
 import 'package:notiyou/screens/config_page.dart';
 import 'package:notiyou/routes/index.dart';
-import 'package:notiyou/repositories/mission_time_repository_remote.dart';
+import 'package:notiyou/services/mission_service.dart';
+import 'package:notiyou/services/supabase_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockSupabaseClient extends Mock implements SupabaseClient {}
+
+class MockGotrueClient extends Mock implements GoTrueClient {}
 
 void main() {
+  final MockSupabaseClient mockSupabaseClient = MockSupabaseClient();
+
   group('SignupPage 테스트', () {
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      await MissionTimeRepositoryRemote.init();
+      SupabaseService.setMockClient(mockSupabaseClient);
+      // TODO: 테스트 전용 Mock 서비스 작성되면 좋겠다.
+      MissionService.switchToLocalRepository();
     });
 
     testWidgets('완료 버튼을 누르면 온보딩 모드로 설정 페이지로 이동한다', (tester) async {

--- a/test/screens/signup_page_test.dart
+++ b/test/screens/signup_page_test.dart
@@ -4,14 +4,14 @@ import 'package:go_router/go_router.dart';
 import 'package:notiyou/screens/signup_page.dart';
 import 'package:notiyou/screens/config_page.dart';
 import 'package:notiyou/routes/index.dart';
-import 'package:notiyou/repositories/mission_time_repository.dart';
+import 'package:notiyou/repositories/mission_time_repository_remote.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group('SignupPage 테스트', () {
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      await MissionTimeRepository.init();
+      await MissionTimeRepositoryRemote.init();
     });
 
     testWidgets('완료 버튼을 누르면 온보딩 모드로 설정 페이지로 이동한다', (tester) async {

--- a/test/screens/signup_page_test.dart
+++ b/test/screens/signup_page_test.dart
@@ -1,49 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:notiyou/screens/signup_page.dart';
 import 'package:notiyou/screens/config_page.dart';
-import 'package:notiyou/routes/index.dart';
-import 'package:notiyou/services/mission_service.dart';
-import 'package:notiyou/services/supabase_service.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:mocktail/mocktail.dart';
 
-class MockSupabaseClient extends Mock implements SupabaseClient {}
-
-class MockGotrueClient extends Mock implements GoTrueClient {}
+class MockGoRouter extends Mock implements GoRouter {}
 
 void main() {
-  final MockSupabaseClient mockSupabaseClient = MockSupabaseClient();
-
   group('SignupPage 테스트', () {
-    setUp(() async {
-      SharedPreferences.setMockInitialValues({});
-      SupabaseService.setMockClient(mockSupabaseClient);
-      // TODO: 테스트 전용 Mock 서비스 작성되면 좋겠다.
-      MissionService.switchToLocalRepository();
+    late MockGoRouter mockRouter;
+
+    setUp(() {
+      mockRouter = MockGoRouter();
     });
 
     testWidgets('완료 버튼을 누르면 온보딩 모드로 설정 페이지로 이동한다', (tester) async {
-      final router = GoRouter(
-        initialLocation: SignupPage.routeName,
-        routes: routes,
-      );
+      when(() => mockRouter.go(any())).thenReturn(null);
 
       await tester.pumpWidget(
-        MaterialApp.router(
-          routerConfig: router,
+        MaterialApp(
+          home: InheritedGoRouter(
+            goRouter: mockRouter,
+            child: const SignupPage(),
+          ),
         ),
       );
 
       await tester.tap(find.text('완료'));
       await tester.pumpAndSettle();
 
-      expect(
-        router.routeInformationProvider.value.uri.toString(),
-        ConfigPage.onboardingRouteName,
-      );
+      verify(() => mockRouter.go(ConfigPage.onboardingRouteName)).called(1);
     });
   });
 }


### PR DESCRIPTION
## 요약

기존의 로컬 저장소를 이용하여 미션 시간 정보를 관리하던 mission_time_repository의 remote용을 작성하여 기존 사용처 코드를 대체합니다.
- 서비스레이어의 비즈니스 로직에 영향을 주지 않기 위해 mission_time_repository의 인터페이스를 정의하여 사용했습니다.
- 정의된 인터페이스를 활용하기 위해서, 기존에 static으로 정의되어 있던 메서드 및 프로퍼티들을 모두 인스턴스 프로퍼티, 메서드로 전환하고, `싱글턴 패턴`의 클래스로 변경하였습니다.

## 작업 내용

- [feat: supabase의 미션테이블을 사용하는 mission_time_respository_remote 작성 및 기존 코드 교체](https://github.com/buku-buku/notiyou/pull/29/commits/a91213bb5a3d2ac7c67cf6f235d4fecc64f543ad)
- [test: 테스트를 위한 메서드 작성 및 테스트코드에 적용](https://github.com/buku-buku/notiyou/pull/29/commits/5d383f774d94c51e4a9f8e7d8dfab8c5970483be)

### Supabase 작업 사항

- [missions 테이블](https://supabase.com/dashboard/project/pmiivbdkefsnzznxghwb/editor/40376?schema=public)을 생성하였습니다.
  - [Row Level Security](https://supabase.com/docs/guides/database/postgres/row-level-security) 정책 설정을 통해, 본인의 데이터만을 조회하고 수정할 수 있도록 권한을 설정하였습니다. 
  -  <img width="1075" alt="image" src="https://github.com/user-attachments/assets/e8b02fc2-983a-42c8-9dd4-8431838f2aac">



## 기타 사항

- 그래도 나름 Dart를 학습해가면서 조금씩 cursor의 composer 사용 빈도를 줄여가며 작업하고 있는데요, 그러다보니 dart 언어 작성 자체에는 어느정도 익숙해져가는것 같습니다. 대체로 flutter 영역 밖에서 코드를 작성하다보니 더 그러한것 같네요.

## 체크리스트

없을것 같습니다..?

## 스크린샷

![화면 기록 2024-11-28 오전 1 04 40](https://github.com/user-attachments/assets/1c1231f5-8f8f-45a4-b2a0-a30ea176545a)

