### PR TITLE
[NY-64] 로그아웃이 동작하지 않는 문제 수정

### DIFF
--- a/lib/routes/index.dart
+++ b/lib/routes/index.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
 import '../screens/home_page.dart';
 import '../screens/login_page.dart';
 import '../screens/signup_page.dart';
@@ -40,8 +41,15 @@ final routes = <RouteBase>[
             BottomNavigationBarItem(icon: Icon(Icons.settings), label: '설정'),
             BottomNavigationBarItem(icon: Icon(Icons.logout), label: '로그아웃'),
           ],
-          onTap: (index) {
-            context.go(bottomNavigationRoutes[index].path);
+          onTap: (index) async {
+            if (index == 3) {
+              await AuthService.logout();
+              if (context.mounted) {
+                context.go(LoginPage.routeName);
+              }
+            } else {
+              context.go(bottomNavigationRoutes[index].path);
+            }
           },
         ),
       );

--- a/lib/services/auth/kakao_auth_service.dart
+++ b/lib/services/auth/kakao_auth_service.dart
@@ -15,7 +15,6 @@ class KakaoAuthService {
       if (error.code == 'CANCELED') {
         return null;
       }
-
       return await _loginWithKakaoAccount();
     }
   }
@@ -43,6 +42,8 @@ class KakaoAuthService {
   }
 
   static Future<void> logout() async {
-    await _kakaoUserApi.logout();
+    if (await kakao.AuthApi.instance.hasToken()) {
+      await _kakaoUserApi.logout();
+    }
   }
 }

--- a/lib/services/auth/supabase_auth_service.dart
+++ b/lib/services/auth/supabase_auth_service.dart
@@ -15,8 +15,7 @@ class SupabaseAuthService {
   }
 
   static Future<supabase.User?> getUser() async {
-    final response = await SupabaseService.client.auth.getUser();
-    return response.user;
+    return SupabaseService.client.auth.currentUser;
   }
 
   static bool isRegistrationCompleted(supabase.User user) {


### PR DESCRIPTION
## 요약

로그아웃이 동작하지 않는 문제를 수정합니다.

## 작업 내용

- [fix: 로그아웃이 동작하지 않는 문제 수정](https://github.com/buku-buku/notiyou/pull/30/commits/14b6c08c5e7415b9f7db88a19d104507fb20f7ab)
- [fix: SupabaseAuthService.getUser가 유저정보를 로컬 데이터로 조회해오도록 수정](https://github.com/buku-buku/notiyou/pull/30/commits/41f1a882b66d4dbdf938937b830a721103222d83)
  -  이따금씩 remote에서 유저정보를 불러오지 못하는 경우가 있는데, 이때 에러를 던지지 않고 무한으로 함수 호출이 resolve 되지 않더라구요. 그래서 그냥 로컬상에 저장해둔 유저정보를 반환하는 것으로 바꿨습니다.
