### PR TITLE
[NY-65] 안드로이드 알림 권한이 부족한 문제 수정

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 >
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
   <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+  <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
   <uses-permission android:name="android.permission.VIBRATE" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
   <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
## 요약

local_notification에서 필요로한 안드로이드 알림 권한이 누락되어 있어 이를 수정합니다.

## 작업 내용

- 커밋을 기준으로 설명합니다.

## 기타 사항

- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등을 설명합니다.

## 체크리스트

- Merge/배포 후에 체크해야 할 사항이 있으면 적어주세요.

## 스크린샷

- 필요시, 추가되는 기능이나 고친 버그 등을 잘 보여주는 스크린샷을 첨부합니다.
