### PR TITLE
[NY-67] 절대 경로 import 린트 룰 추가

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
     "editor.tabCompletion": "onlySnippets",
     "editor.wordBasedSuggestions": "off",
     "editor.codeActionsOnSave": {
+      "source.fixAll": "always",
       "quickfix.insertSemicolon.multi": "always"
     }
   },

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    - always_use_package_imports

--- a/lib/fixtures/mission_history.dart
+++ b/lib/fixtures/mission_history.dart
@@ -1,6 +1,6 @@
 // 🚨 fixtures 폴더는 supabase에서 데이터를 가져오는 것이 완성되면 삭제합니다. 개발 편의를 위해 작성된 임시 데이터입니다.
 
-import '../models/mission_history.dart';
+import 'package:notiyou/models/mission_history.dart';
 
 final baseDate = DateTime.parse('2024-11-22 13:00:00');
 const missionCountOnDay = 2;

--- a/lib/layouts/back_button_layout.dart
+++ b/lib/layouts/back_button_layout.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import '../screens/home_page.dart';
+import 'package:notiyou/screens/home_page.dart';
 
 class BackButtonLayout extends StatelessWidget {
   final Widget child;

--- a/lib/layouts/bottom_nav_layout.dart
+++ b/lib/layouts/bottom_nav_layout.dart
@@ -3,9 +3,9 @@ import 'package:go_router/go_router.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_user.dart';
 import 'package:notiyou/screens/splash_page.dart';
 
-import '../screens/config_page.dart';
-import '../screens/history_page.dart';
-import '../screens/home_page.dart';
+import 'package:notiyou/screens/config_page.dart';
+import 'package:notiyou/screens/history_page.dart';
+import 'package:notiyou/screens/home_page.dart';
 
 class BottomNavLayout extends StatelessWidget {
   final Widget child;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,9 +4,9 @@ import 'package:intl/date_symbol_data_local.dart';
 
 import 'package:notiyou/services/dotenv_service.dart';
 import 'package:notiyou/services/supabase_service.dart';
-import 'routes/router.dart';
-import 'services/mission_service.dart';
-import 'services/mission_alarm_service.dart';
+import 'package:notiyou/routes/router.dart';
+import 'package:notiyou/services/mission_service.dart';
+import 'package:notiyou/services/mission_alarm_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/lib/models/mission.dart
+++ b/lib/models/mission.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../utils/time_utils.dart';
+import 'package:notiyou/utils/time_utils.dart';
 
 class Mission {
   final String id;

--- a/lib/repositories/mission_repository_interface.dart
+++ b/lib/repositories/mission_repository_interface.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../models/mission.dart';
+import 'package:notiyou/models/mission.dart';
 
 abstract interface class MissionRepository {
   Future<void> init();

--- a/lib/repositories/mission_repository_local.dart
+++ b/lib/repositories/mission_repository_local.dart
@@ -4,8 +4,8 @@ import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:notiyou/repositories/mission_time_repository_local.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:convert';
-import '../models/mission.dart';
-import '../utils/time_utils.dart';
+import 'package:notiyou/models/mission.dart';
+import 'package:notiyou/utils/time_utils.dart';
 
 /// 미션 데이터를 관리하는 저장소입니다.
 ///

--- a/lib/repositories/mission_time_repository_local.dart
+++ b/lib/repositories/mission_time_repository_local.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import '../utils/time_utils.dart';
+import 'package:notiyou/utils/time_utils.dart';
 
 /// 미션 시간 데이터를 관리하는 저장소입니다.
 ///

--- a/lib/repositories/mission_time_repository_remote.dart
+++ b/lib/repositories/mission_time_repository_remote.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:notiyou/services/supabase_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import '../utils/time_utils.dart';
+import 'package:notiyou/utils/time_utils.dart';
 
 /// 미션 시간 데이터를 관리하는 저장소입니다.
 ///

--- a/lib/repositories/supporter_repository.dart
+++ b/lib/repositories/supporter_repository.dart
@@ -1,4 +1,4 @@
-import '../services/supabase_service.dart';
+import 'package:notiyou/services/supabase_service.dart';
 
 class SupporterRepository {
   static Future<Map<String, dynamic>?> getSupporter(String userId) async {

--- a/lib/routes/index.dart
+++ b/lib/routes/index.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
-import '../screens/home_page.dart';
-import '../screens/login_page.dart';
-import '../screens/signup_page.dart';
-import '../screens/config_page.dart';
-import '../screens/history_page.dart';
-import '../screens/splash_page.dart';
+import 'package:notiyou/screens/home_page.dart';
+import 'package:notiyou/screens/login_page.dart';
+import 'package:notiyou/screens/signup_page.dart';
+import 'package:notiyou/screens/config_page.dart';
+import 'package:notiyou/screens/history_page.dart';
+import 'package:notiyou/screens/splash_page.dart';
 
 final routes = <RouteBase>[
   GoRoute(

--- a/lib/routes/router.dart
+++ b/lib/routes/router.dart
@@ -1,6 +1,6 @@
 import 'package:go_router/go_router.dart';
 import 'package:notiyou/routes/index.dart';
-import '../screens/splash_page.dart';
+import 'package:notiyou/screens/splash_page.dart';
 
 final router = GoRouter(
   initialLocation: SplashPage.routeName,

--- a/lib/screens/config_page.dart
+++ b/lib/screens/config_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'home_page.dart';
-import '../services/mission_service.dart';
-import '../widgets/notification_template_config.dart';
-import '../widgets/supporter_section.dart';
+import 'package:notiyou/screens/home_page.dart';
+import 'package:notiyou/services/mission_service.dart';
+import 'package:notiyou/widgets/notification_template_config.dart';
+import 'package:notiyou/widgets/supporter_section.dart';
 
 class ConfigPage extends StatefulWidget {
   static const String routeName = '/config';

--- a/lib/screens/history_page.dart
+++ b/lib/screens/history_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import '../utils/time_utils.dart';
-import '../widgets/mission_history_list_item.dart';
-import '../models/mission_history.dart';
-import '../services/mission_history_service.dart';
+import 'package:notiyou/utils/time_utils.dart';
+import 'package:notiyou/widgets/mission_history_list_item.dart';
+import 'package:notiyou/models/mission_history.dart';
+import 'package:notiyou/services/mission_history_service.dart';
 
 class HistoryPage extends StatefulWidget {
   const HistoryPage({super.key});

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:notiyou/models/mission.dart';
-import '../services/mission_service.dart';
+import 'package:notiyou/services/mission_service.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -4,7 +4,7 @@ import 'package:notiyou/screens/config_page.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
 
-import 'signup_page.dart';
+import 'package:notiyou/screens/signup_page.dart';
 
 class LoginPage extends StatelessWidget {
   const LoginPage({super.key});

--- a/lib/screens/signup_page.dart
+++ b/lib/screens/signup_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'config_page.dart';
+import 'package:notiyou/screens/config_page.dart';
 
 class SignupPage extends StatelessWidget {
   const SignupPage({super.key});

--- a/lib/screens/splash_page.dart
+++ b/lib/screens/splash_page.dart
@@ -3,8 +3,8 @@ import 'package:go_router/go_router.dart';
 import 'package:notiyou/screens/config_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
 
-import 'home_page.dart';
-import 'login_page.dart';
+import 'package:notiyou/screens/home_page.dart';
+import 'package:notiyou/screens/login_page.dart';
 
 class SplashPage extends StatefulWidget {
   const SplashPage({super.key});

--- a/lib/services/mission_alarm_service.dart
+++ b/lib/services/mission_alarm_service.dart
@@ -5,7 +5,7 @@ import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:notiyou/services/local_notification_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import '../routes/router.dart';
+import 'package:notiyou/routes/router.dart';
 
 class MissionAlarmService {
   static final MissionTimeRepository _missionTimeRepository =

--- a/lib/services/mission_history_service.dart
+++ b/lib/services/mission_history_service.dart
@@ -1,5 +1,5 @@
-import '../models/mission_history.dart';
-import '../fixtures/mission_history.dart';
+import 'package:notiyou/models/mission_history.dart';
+import 'package:notiyou/fixtures/mission_history.dart';
 
 class MissionHistoryService {
   static Future<List<MissionHistory>> getMissionHistoriesByUserId(

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -5,8 +5,8 @@ import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:notiyou/repositories/mission_time_repository_local.dart';
 import 'package:notiyou/repositories/mission_time_repository_remote.dart';
 import 'package:notiyou/services/mission_alarm_service.dart';
-import '../models/mission.dart';
-import '../repositories/mission_repository_local.dart';
+import 'package:notiyou/models/mission.dart';
+import 'package:notiyou/repositories/mission_repository_local.dart';
 
 class MissionService {
   static MissionTimeRepository _missionTimeRepository =

--- a/lib/services/notification_template_service.dart
+++ b/lib/services/notification_template_service.dart
@@ -1,4 +1,4 @@
-import '../repositories/notification_template_repository.dart';
+import 'package:notiyou/repositories/notification_template_repository.dart';
 
 class NotificationTemplateService {
   static Future<String> getSuccessMessageTemplate() async {

--- a/lib/services/supporter_service.dart
+++ b/lib/services/supporter_service.dart
@@ -1,6 +1,6 @@
 import 'package:notiyou/services/auth/auth_service.dart';
 
-import '../repositories/supporter_repository.dart';
+import 'package:notiyou/repositories/supporter_repository.dart';
 
 class SupporterService {
   static Future<Map<String, dynamic>?> getSupporter() async {

--- a/lib/widgets/mission_history_list_item.dart
+++ b/lib/widgets/mission_history_list_item.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../models/mission_history.dart';
+import 'package:notiyou/models/mission_history.dart';
 
 const incompleteText = '미완료';
 const done = (color: Colors.green, icon: Icons.check_circle);

--- a/lib/widgets/notification_template_config.dart
+++ b/lib/widgets/notification_template_config.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../services/notification_template_service.dart';
+import 'package:notiyou/services/notification_template_service.dart';
 
 class NotificationTemplateConfig extends StatefulWidget {
   const NotificationTemplateConfig({super.key});

--- a/lib/widgets/supporter_section.dart
+++ b/lib/widgets/supporter_section.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
-import '../services/auth/auth_service.dart';
-import '../services/supporter_service.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
+import 'package:notiyou/services/supporter_service.dart';
 
 class SupporterSection extends StatefulWidget {
   const SupporterSection({super.key});


### PR DESCRIPTION
## 요약

프로젝트 내부 모듈을 절대 경로로 import 하도록 통일하는 린트 룰을 추가합니다

## 작업 사항

- [chore: lint always use package imports](https://github.com/buku-buku/notiyou/pull/32/commits/04e15ea91d488c40d0a17c0d512de31990905e12)
- [chore: 저장하면 자동 fix 되도록 vscode 설정 추가](https://github.com/buku-buku/notiyou/pull/32/commits/f0f94b9c3de421b99de7d01b51457231699edfcb)
- [lint: 절대 경로 lint rule 적용](https://github.com/buku-buku/notiyou/pull/32/commits/bb95529cf79f7dab3c31ea0e56d6b58a4f0096cc)

## 기타 사항

- PR 충돌을 최소화하기 위해 다음과 같이 진행합니다
  - 다 같이 모여서 기존에 올라온 PR을 모두 머지한다
  - 해당 PR의 브랜치에서 아래 명령어를 실행해서 린트 fix를 진행한다
  - 해당 PR을 머지한다

```sh
# fix
dart fix --apply
```

## 링크

- https://stackoverflow.com/questions/61708945/how-to-fix-auto-fixable-problems-on-vscode-with-flutter