### PR TITLE
[NY-69] mission.copyWith에서 completedAt이 null로 업데이트 되지 않는 버그 해결

### DIFF
--- a/lib/models/mission.dart
+++ b/lib/models/mission.dart
@@ -26,15 +26,17 @@ class Mission {
     bool? isCompleted,
     DateTime? completedAt,
     DateTime? date,
-  }) =>
-      Mission(
-        id: id ?? this.id,
-        missionNumber: missionNumber ?? this.missionNumber,
-        time: time ?? this.time,
-        isCompleted: isCompleted ?? this.isCompleted,
-        completedAt: completedAt ?? this.completedAt,
-        date: date ?? this.date,
-      );
+  }) {
+    final newIsCompleted = isCompleted ?? this.isCompleted;
+    return Mission(
+      id: id ?? this.id,
+      missionNumber: missionNumber ?? this.missionNumber,
+      time: time ?? this.time,
+      isCompleted: newIsCompleted,
+      completedAt: newIsCompleted ? (completedAt ?? this.completedAt) : null,
+      date: date ?? this.date,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
         'id': id,

--- a/test/models/mission_test.dart
+++ b/test/models/mission_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:notiyou/models/mission.dart';
+
+void main() {
+  group('Mission.copyWith()', () {
+    late Mission mission;
+
+    setUp(() {
+      mission = Mission(
+        id: 'test-id',
+        missionNumber: 1,
+        time: const TimeOfDay(hour: 9, minute: 0),
+        isCompleted: false,
+        completedAt: null,
+        date: DateTime(2024, 3, 20),
+      );
+    });
+
+    test('파라미터를 전달하지 않으면, 원래 값이 유지된다', () {
+      final copied = mission.copyWith();
+
+      expect(copied.id, mission.id);
+      expect(copied.missionNumber, mission.missionNumber);
+      expect(copied.time, mission.time);
+      expect(copied.isCompleted, mission.isCompleted);
+      expect(copied.completedAt, mission.completedAt);
+      expect(copied.date, mission.date);
+    });
+
+    test('미션을 미완료 상태로 변경하면, completedAt은 값을 전달하든 전달하지 않든 항상 null이 된다', () {
+      final completed = mission.copyWith(
+        isCompleted: true,
+        completedAt: DateTime(2024, 3, 20),
+      );
+
+      final uncompleted = completed.copyWith(
+        isCompleted: false,
+      );
+
+      expect(uncompleted.isCompleted, false);
+      expect(uncompleted.completedAt, null);
+
+      final uncompleted2 = completed.copyWith(
+        isCompleted: false,
+        completedAt: DateTime(2024, 3, 21),
+      );
+
+      expect(uncompleted2.isCompleted, false);
+      expect(uncompleted2.completedAt, null);
+
+      final uncompleted3 = completed.copyWith(
+        isCompleted: false,
+        completedAt: null,
+      );
+
+      expect(uncompleted3.isCompleted, false);
+      expect(uncompleted3.completedAt, null);
+    });
+  });
+}


### PR DESCRIPTION
## 요약

홈 페이지에서 사용자가 미션을 체크했다가 다시 해제하면 completedAt이 null로 변경되어야 하는데 이전 completedAt 값이 남아 있는 문제를 해결합니다.

## 작업 내용

- [fix: mission.copyWith에서 completedAt이 null로 업데이트 되지 않는 버그 해결](https://github.com/buku-buku/notiyou/pull/33/commits/25177482fea02c0ff52ca6bdcbbf3b269be7e67a)
- [spec: mission.copyWith에서 isCompleted=false이면 completedAt=null 테스트](https://github.com/buku-buku/notiyou/pull/33/commits/37157a43529e1f1043d0c2c658f4735ae7cb1e37)

## 스크린샷

> 정상 동작 화면:

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/2f5dd592-ebac-4035-bf7a-9b89808a75d9">
