### PR TITLE
[NY-70] mission_history 테이블에서 mission_at 필드 관리되도록 변경

### DIFF
--- a/lib/models/mission.dart
+++ b/lib/models/mission.dart
@@ -62,7 +62,7 @@ class Mission {
       Mission(
         id: json['id'].toString(),
         missionNumber: json['missions']['mission_number'],
-        time: TimeUtils.parseTime(json['missions']['mission_at']),
+        time: TimeUtils.parseTime(json['mission_at']),
         isCompleted: json['done_at'] != null,
         completedAt:
             json['done_at'] != null ? DateTime.parse(json['done_at']) : null,


### PR DESCRIPTION
## 요약

### As-Is

mission_id를 통해 mission table에 접근하여 mission_at 값을 가져오고 있다.

- (Cons) 무조건 최신으로 설정된 시간으로 동기화되어 관리된다.
- (Cons) 이후 이전 미션 내역들을 조회시, 그 시점에 설정된 미션 시간이 아닌, 최신에 설정된 미션 시간으로 조회된다.

### To-Be

mission_history 테이블에 mission_at 필드를 추가하고, missions 테이블과는 별도로 관리한다.

- (Pros) 무조건 최신 설정된 시간으로 동기화되지 않아도 된다. 정책에 따라 선택 가능
- (Pros) 이전 미션 내역들을 조회할때, 그 시점에 설정된 미션 시간을 조회할 수 있다.

- supabase mission_history 테이블에 mission_at 컬럼 추가
![image](https://github.com/user-attachments/assets/55045154-9615-402e-be54-5b5a5e2ee75c)

## 작업 내용

- [feat: mission_history 테이블에서 mission_at 필드 관리되도록 변경](https://github.com/buku-buku/notiyou/pull/36/commits/fde375f302f92996fd64157caac9798c8a3b3ad3)

## 이후 하면 좋겠는 작업

- mission_number 컬럼을 제거하고, 관련 로직들을 mission_id를 활용하는 방식으로 대체하려고 합니다.
  - mission_number 컬럼이 있고, 이를 통해 미션을 검색하는 방식은 기능의 복잡도를 높이게 될것 같다는 생각이 많이 듭니다. mission_number 컬럼이 없더라도 mission_id를 통해 충분히 기존의 기능들을 제공할 수 있고, 로직의 복잡도도 줄일수 있을것 같다는 생각이 들어.
