### PR TITLE
[NY-62] 안드로이드 notification 에러 해결 및 PushAlarmService 리팩토링

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -72,6 +72,24 @@
         />
       </intent-filter>
     </activity>
+
+    <!-- Specify the following between the <application> tags so that the plugin can actually show the scheduled notification(s) -->
+    <!-- @see https://pub.dev/packages/flutter_local_notifications#androidmanifestxml-setup -->
+    <receiver
+      android:exported="false"
+      android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver"
+    />
+    <receiver
+      android:exported="false"
+      android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver"
+    >
+      <intent-filter>
+        <action android:name="android.intent.action.BOOT_COMPLETED" />
+        <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+        <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+        <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
+      </intent-filter>
+    </receiver>
   </application>
   <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,8 @@
       android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
       android:hardwareAccelerated="true"
       android:windowSoftInputMode="adjustResize"
+      android:showWhenLocked="true"
+      android:turnScreenOn="true"
     >
       <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,16 +34,21 @@
         android:name="io.flutter.embedding.android.NormalTheme"
         android:resource="@style/NormalTheme"
       />
+      <!-- 기본 실행을 위한 intent-filter -->
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+
+      <!-- 카카오 관련 intent-filter를 별도로 분리 -->
+      <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
-        <!-- "kakao${YOUR_NATIVE_APP_KEY}://${PRODUCT_NAME}" 형식의 앱 실행 스킴 설정 -->
-        <!-- 카카오톡 공유, 카카오톡 메시지 -->
-        <data android:host="kakaolink"
-            android:scheme="kakao${KAKAO_NATIVE_APP_KEY}" />
+        <data
+          android:host="kakaolink"
+          android:scheme="kakao${KAKAO_NATIVE_APP_KEY}"
+        />
       </intent-filter>
     </activity>
     <!-- Don't delete the meta-data below.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:notiyou/services/dotenv_service.dart';
 import 'package:notiyou/services/supabase_service.dart';
 import 'routes/router.dart';
 import 'services/mission_service.dart';
-import 'services/push_alarm_service.dart';
+import 'services/mission_alarm_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -18,7 +18,7 @@ void main() async {
   );
   await SupabaseService.init();
   await MissionService.init();
-  await PushAlarmService.init();
+  await MissionAlarmService.init();
   runApp(const MyApp());
 }
 

--- a/lib/services/local_notification_service.dart
+++ b/lib/services/local_notification_service.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+const String notificationChannelId = 'NotiYou - Mission Alarm ID';
+const String notificationChannelName = 'NotiYou - Mission Alarm';
+const String notificationChannelDescription = 'Mission time notification';
+
+const notificationDetails = NotificationDetails(
+  android: AndroidNotificationDetails(
+    notificationChannelId,
+    notificationChannelName,
+    channelDescription: notificationChannelDescription,
+    importance: Importance.max,
+    priority: Priority.high,
+  ),
+  iOS: DarwinNotificationDetails(
+    presentAlert: true,
+    presentBadge: true,
+    presentSound: true,
+  ),
+);
+
+class LocalNotificationService {
+  static final FlutterLocalNotificationsPlugin _notifications =
+      FlutterLocalNotificationsPlugin();
+
+  static void Function(String?)? onNotificationTap;
+
+  static int _notificationId = 0;
+
+  static Future<void> init({
+    void Function(String?)? onNotificationTapped,
+  }) async {
+    onNotificationTap = onNotificationTapped;
+
+    await _initializeTimeZone();
+    await _initializeSettings();
+    await _requestPermissions();
+  }
+
+  static Future<void> _initializeTimeZone() async {
+    tz.initializeTimeZones();
+    tz.setLocalLocation(tz.getLocation('Asia/Seoul'));
+  }
+
+  static Future<void> _initializeSettings() async {
+    const androidSettings =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosSettings = DarwinInitializationSettings();
+    const settings = InitializationSettings(
+      android: androidSettings,
+      iOS: iosSettings,
+    );
+
+    await _notifications.initialize(
+      settings,
+      onDidReceiveNotificationResponse: (NotificationResponse details) {
+        if (onNotificationTap != null) {
+          onNotificationTap!(details.payload);
+        }
+      },
+    );
+  }
+
+  static Future<void> _requestPermissions() async {
+    await _requestAndroidPermissions();
+    await _requestIOSPermissions();
+  }
+
+  static Future<void> _requestAndroidPermissions() async {
+    await _notifications
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.requestNotificationsPermission();
+  }
+
+  static Future<void> _requestIOSPermissions() async {
+    await _notifications
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>()
+        ?.requestPermissions(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
+  }
+
+  static Future<int> scheduleNotification({
+    int? id,
+    required String title,
+    required String body,
+    required DateTime scheduledTime,
+    required String payload,
+  }) async {
+    final newId = id ?? _notificationId++;
+
+    await _notifications.zonedSchedule(
+      newId,
+      title,
+      body,
+      tz.TZDateTime.from(scheduledTime, tz.local),
+      notificationDetails,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      payload: payload,
+    );
+
+    return newId;
+  }
+
+  static Future<void> cancelNotification(int id) async {
+    await _notifications.cancel(id);
+  }
+
+  static Future<void> cancelAllNotifications() async {
+    await _notifications.cancelAll();
+  }
+
+  static Future<void> showNotification({
+    int? id,
+    String? title = '테스트 알림',
+    String? body = '이것은 테스트 알림입니다.',
+    String? payload,
+  }) async {
+    await _notifications.show(
+      id ?? _notificationId++,
+      title,
+      body,
+      notificationDetails,
+      payload: payload,
+    );
+  }
+}

--- a/lib/services/local_notification_service.dart
+++ b/lib/services/local_notification_service.dart
@@ -21,6 +21,13 @@ const notificationDetails = NotificationDetails(
   ),
 );
 
+const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+const iosSettings = DarwinInitializationSettings();
+const settings = InitializationSettings(
+  android: androidSettings,
+  iOS: iosSettings,
+);
+
 class LocalNotificationService {
   static final FlutterLocalNotificationsPlugin _notifications =
       FlutterLocalNotificationsPlugin();
@@ -45,14 +52,6 @@ class LocalNotificationService {
   }
 
   static Future<void> _initializeSettings() async {
-    const androidSettings =
-        AndroidInitializationSettings('@mipmap/ic_launcher');
-    const iosSettings = DarwinInitializationSettings();
-    const settings = InitializationSettings(
-      android: androidSettings,
-      iOS: iosSettings,
-    );
-
     await _notifications.initialize(
       settings,
       onDidReceiveNotificationResponse: (NotificationResponse details) {

--- a/lib/services/mission_alarm_service.dart
+++ b/lib/services/mission_alarm_service.dart
@@ -7,7 +7,7 @@ import 'package:notiyou/services/local_notification_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../routes/router.dart';
 
-class PushAlarmService {
+class MissionAlarmService {
   static final MissionTimeRepository _missionTimeRepository =
       MissionTimeRepositoryRemote();
 
@@ -40,14 +40,14 @@ class PushAlarmService {
     final secondMissionTime = await _missionTimeRepository.getMissionTime(2);
 
     if (firstMissionTime != null) {
-      await scheduleMissionPushAlarm(1, firstMissionTime);
+      await scheduleAlarm(1, firstMissionTime);
     }
     if (secondMissionTime != null) {
-      await scheduleMissionPushAlarm(2, secondMissionTime);
+      await scheduleAlarm(2, secondMissionTime);
     }
   }
 
-  static Future<void> scheduleMissionPushAlarm(
+  static Future<void> scheduleAlarm(
       int missionNumber, TimeOfDay missionTime) async {
     final now = DateTime.now();
     var scheduledTime = DateTime(
@@ -71,20 +71,19 @@ class PushAlarmService {
     );
   }
 
-  static Future<void> cancelMissionPushAlarm(int missionNumber) async {
+  static Future<void> cancelAlarm(int missionNumber) async {
     await LocalNotificationService.cancelNotification(missionNumber);
   }
 
-  static Future<void> cancelAllMissionPushAlarms() async {
+  static Future<void> cancelAllAlarms() async {
     await LocalNotificationService.cancelAllNotifications();
   }
 
-  static Future<void> updateMissionPushAlarm(
-      int missionNumber, TimeOfDay? time) async {
-    await cancelMissionPushAlarm(missionNumber);
+  static Future<void> updateAlarm(int missionNumber, TimeOfDay? time) async {
+    await cancelAlarm(missionNumber);
 
     if (time != null) {
-      await scheduleMissionPushAlarm(missionNumber, time);
+      await scheduleAlarm(missionNumber, time);
     }
   }
 }

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -4,9 +4,9 @@ import 'package:notiyou/repositories/mission_repository_remote.dart';
 import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:notiyou/repositories/mission_time_repository_local.dart';
 import 'package:notiyou/repositories/mission_time_repository_remote.dart';
+import 'package:notiyou/services/mission_alarm_service.dart';
 import '../models/mission.dart';
 import '../repositories/mission_repository_local.dart';
-import '../services/push_alarm_service.dart';
 
 class MissionService {
   static MissionTimeRepository _missionTimeRepository =
@@ -37,7 +37,7 @@ class MissionService {
       await _missionRepository.removeTodayMission(missionNumber);
     }
 
-    await PushAlarmService.updateMissionPushAlarm(missionNumber, time);
+    await MissionAlarmService.updateAlarm(missionNumber, time);
   }
 
   // 미션 시간 불러오기


### PR DESCRIPTION
## 요약

안드로이드에서 notification이 정상 동작하도록 해결합니다. 

(트러블슈팅 과정에서 PushAlarmService 코드가 여러 로직(`MissionRepsitory` + `FlutterLocalNotificationsPlugin`)이 섞여 있어서 조작하는 게 쉽지 않아서 두 로직을 분리하는 리팩터링도 같이 진행했습니다.

## 작업 내용

- [feat: full-screen intent notifications](https://github.com/buku-buku/notiyou/pull/38/commits/53c5b2dff5d9af39b11749b9b8635adc30ca9ce2)
- [feat: LocalNotificationService 추가](https://github.com/buku-buku/notiyou/pull/38/commits/6ec349a31a47ecc6cb1355182b3fa5c346f5a1cd)
- [fix: 에러 해결을 위해 안드로이드 intent xml 수정](https://github.com/buku-buku/notiyou/pull/38/commits/e17081edc78f7ad0382933db6653d066a7f1fc02)
- [fix: android에서 scheduled notification 받을 수 있도록 xml 수정](https://github.com/buku-buku/notiyou/pull/38/commits/48bedc8d51853d9071977d6181fdd0f4bfd8cce2)
- [refactor: PushAlarmService가 LocalNotificationService 사용하도록 변경](https://github.com/buku-buku/notiyou/pull/38/commits/784b9c3beffd7710099e2d56b9e1ccd9ad6420d0)
- [refactor: PushAlarmService => MissionAlarmService 이름 변경](https://github.com/buku-buku/notiyou/pull/38/commits/17d7791d1950928fcd0fe27c6fd58b42b776ecce)

## 기타 사항

- 이 PR 브랜치를 지금 메인 브랜치에 rebase 했더니 설정 페이지에서 미션을 설정해도 홈에서 미션이 안 생기더라고요? 그래서 일단 메인 브랜치 rebase 하지 않은 버전으로 PR 올립니다.

## 체크리스트

- [x] 위 기타 사항에 적은 메인 브랜치 동작 점검 - LocalNotificationService 되는 것 확인 완료

## 스크린샷


https://github.com/user-attachments/assets/1f294393-9582-42e9-8e97-60ade19b4edc



