### PR TITLE
[NY-72] mission_service 클래스의 책임 분리 및 미션 관련 레포지토리 개선

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:notiyou/services/dotenv_service.dart';
 import 'package:notiyou/services/supabase_service.dart';
 import 'package:notiyou/routes/router.dart';
-import 'package:notiyou/services/mission_service.dart';
+import 'package:notiyou/services/mission_config_service.dart';
 import 'package:notiyou/services/mission_alarm_service.dart';
 
 void main() async {
@@ -17,7 +17,7 @@ void main() async {
     nativeAppKey: DotEnvService.getValue('KAKAO_NATIVE_APP_KEY'),
   );
   await SupabaseService.init();
-  await MissionService.init();
+  await MissionConfigService.init();
   await MissionAlarmService.init();
   runApp(const MyApp());
 }

--- a/lib/models/mission.dart
+++ b/lib/models/mission.dart
@@ -61,7 +61,7 @@ class Mission {
   factory Mission.fromMissionHistoryEntity(Map<String, dynamic> json) =>
       Mission(
         id: json['id'].toString(),
-        missionNumber: json['missions']['mission_number'],
+        missionNumber: json['challenger_mission_time']['mission_number'],
         time: TimeUtils.parseTime(json['mission_at']),
         isCompleted: json['done_at'] != null,
         completedAt:

--- a/lib/repositories/mission_history_repository_interface.dart
+++ b/lib/repositories/mission_history_repository_interface.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:notiyou/models/mission.dart';
 
-abstract interface class MissionRepository {
+abstract interface class MissionHistoryRepository {
   Future<void> init();
 
   // TODO: missionId로 생성하도록 변경

--- a/lib/repositories/mission_history_repository_local.dart
+++ b/lib/repositories/mission_history_repository_local.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:notiyou/repositories/mission_repository_interface.dart';
+import 'package:notiyou/repositories/mission_history_repository_interface.dart';
 import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:notiyou/repositories/mission_time_repository_local.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -16,23 +16,23 @@ import 'package:notiyou/utils/time_utils.dart';
 ///
 /// ⚠️: 로컬의 데이터는 오늘의 데이터만 저장됩니다.
 /// 오늘 이후의 모든 데이터는 앱 실행 시 삭제됩니다.
-class MissionRepositoryLocal implements MissionRepository {
+class MissionHistoryRepositoryLocal implements MissionHistoryRepository {
   SharedPreferences? _prefs;
   final String _missionStoreKey = 'mission';
   final MissionTimeRepository _missionTimeRepository =
       MissionTimeRepositoryLocal();
 
 // 싱글턴 인스턴스
-  static final MissionRepositoryLocal _instance =
-      MissionRepositoryLocal._internal();
+  static final MissionHistoryRepositoryLocal _instance =
+      MissionHistoryRepositoryLocal._internal();
 
   // 팩토리 생성자
-  factory MissionRepositoryLocal() {
+  factory MissionHistoryRepositoryLocal() {
     return _instance;
   }
 
   // private 생성자
-  MissionRepositoryLocal._internal();
+  MissionHistoryRepositoryLocal._internal();
 
   @override
   Future<void> init() async {

--- a/lib/repositories/mission_history_repository_remote.dart
+++ b/lib/repositories/mission_history_repository_remote.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:notiyou/models/mission.dart';
-import 'package:notiyou/repositories/mission_repository_interface.dart';
+import 'package:notiyou/repositories/mission_history_repository_interface.dart';
 import 'package:notiyou/services/supabase_service.dart';
 import 'package:notiyou/utils/time_utils.dart';
 
@@ -13,8 +13,8 @@ import 'package:notiyou/utils/time_utils.dart';
 ///
 /// ⚠️: 로컬의 데이터는 오늘의 데이터만 저장됩니다.
 /// 오늘 이후의 모든 데이터는 앱 실행 시 삭제됩니다.
-
-class MissionRepositoryRemote implements MissionRepository {
+/// TODO(무호): supabas의 테이블 명칭을 상수로 관리한다.
+class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
   @override
   Future<Mission?> findMissionById(String id) async {
     final entity =
@@ -23,10 +23,10 @@ class MissionRepositoryRemote implements MissionRepository {
           done_at,
           created_at,
           mission_at,
-          missions (
+          challenger_mission_time (
             id,
             mission_number,
-            user_id
+            challenger_id
           )
         ''').eq('id', id).single();
 
@@ -46,7 +46,7 @@ class MissionRepositoryRemote implements MissionRepository {
     await SupabaseService.client
         .from('mission_history')
         .delete()
-        .eq('missions.mission_number', missionNumber)
+        .eq('challenger_mission_time.mission_number', missionNumber)
         .gte('created_at', today.toUtc().toIso8601String());
   }
 
@@ -66,7 +66,7 @@ class MissionRepositoryRemote implements MissionRepository {
   @override
   Future<void> createTodayMission(int missionNumber) async {
     final newMission = await SupabaseService.client
-        .from('missions')
+        .from('challenger_mission_time')
         .select('id, mission_at')
         .eq('mission_number', missionNumber)
         .single();
@@ -87,7 +87,7 @@ class MissionRepositoryRemote implements MissionRepository {
   // TODO: updateMission 메서드에서 처리
   Future<void> updateTodayMissionTime(int missionNumber, TimeOfDay time) async {
     final mission = await SupabaseService.client
-        .from('missions')
+        .from('challenger_mission_time')
         .select('id')
         .eq('mission_number', missionNumber)
         .single();
@@ -110,10 +110,10 @@ class MissionRepositoryRemote implements MissionRepository {
           done_at,
           created_at,
           mission_at,
-          missions (
+          challenger_mission_time (
             id,
             mission_number,
-            user_id
+            challenger_id
           )
         ''')
         .gte('created_at', yesterday.toUtc().toIso8601String())

--- a/lib/repositories/mission_time_repository_remote.dart
+++ b/lib/repositories/mission_time_repository_remote.dart
@@ -35,9 +35,9 @@ class MissionTimeRepositoryRemote implements MissionTimeRepository {
     }
 
     final mission = await supabaseClient
-        .from('missions')
+        .from('challenger_mission_time')
         .select('mission_at')
-        .eq('user_id', userId)
+        .eq('challenger_id', userId)
         .eq('mission_number', missionNumber);
 
     return mission.isNotEmpty
@@ -53,20 +53,20 @@ class MissionTimeRepositoryRemote implements MissionTimeRepository {
       throw const AuthException('User not found');
     }
     final hasMission = await supabaseClient
-        .from('missions')
+        .from('challenger_mission_time')
         .select('id')
-        .eq('user_id', userId)
+        .eq('challenger_id', userId)
         .eq('mission_number', missionNumber);
 
     if (hasMission.isNotEmpty) {
       await supabaseClient
-          .from('missions')
+          .from('challenger_mission_time')
           .update({'mission_at': TimeUtils.stringifyTime(time)})
-          .eq('user_id', userId)
+          .eq('challenger_id', userId)
           .eq('mission_number', missionNumber);
     } else {
-      await supabaseClient.from('missions').insert({
-        'user_id': userId,
+      await supabaseClient.from('challenger_mission_time').insert({
+        'challenger_id': userId,
         'mission_number': missionNumber,
         'mission_at': TimeUtils.stringifyTime(time),
       });
@@ -81,9 +81,9 @@ class MissionTimeRepositoryRemote implements MissionTimeRepository {
       throw const AuthException('User not found');
     }
     await supabaseClient
-        .from('missions')
+        .from('challenger_mission_time')
         .delete()
-        .eq('user_id', userId)
+        .eq('challenger_id', userId)
         .eq('mission_number', missionNumber);
   }
 }

--- a/lib/screens/config_page.dart
+++ b/lib/screens/config_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:notiyou/screens/home_page.dart';
-import 'package:notiyou/services/mission_service.dart';
+import 'package:notiyou/services/mission_config_service.dart';
 import 'package:notiyou/widgets/notification_template_config.dart';
 import 'package:notiyou/widgets/supporter_section.dart';
 
@@ -29,8 +29,8 @@ class _ConfigPageState extends State<ConfigPage> {
 
   Future<void> _loadSavedTimes() async {
     final results = await Future.wait([
-      MissionService.getMissionTime(1),
-      MissionService.getMissionTime(2),
+      MissionConfigService.getMissionTime(1),
+      MissionConfigService.getMissionTime(2),
     ]);
     setState(() {
       // 병렬 처리
@@ -43,15 +43,15 @@ class _ConfigPageState extends State<ConfigPage> {
   Future<void> _saveTimes() async {
     // 시간이 변경되었는지 확인
     final bool hasTimeChanged =
-        _mission1Time != await MissionService.getMissionTime(1) ||
-            _mission2Time != await MissionService.getMissionTime(2);
+        _mission1Time != await MissionConfigService.getMissionTime(1) ||
+            _mission2Time != await MissionConfigService.getMissionTime(2);
 
     if (hasTimeChanged == false) {
       return;
     }
 
-    await MissionService.saveMissionTime(1, _mission1Time);
-    await MissionService.saveMissionTime(2, _mission2Time);
+    await MissionConfigService.saveMissionTime(1, _mission1Time);
+    await MissionConfigService.saveMissionTime(2, _mission2Time);
   }
 
   Future<void> _selectTime(BuildContext context, bool isFirstMission) async {

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:notiyou/models/mission.dart';
-import 'package:notiyou/services/mission_service.dart';
+import 'package:notiyou/services/mission_history_service.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -21,7 +21,7 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _loadMissions() async {
-    final todaysMissions = await MissionService.getTodaysMissions();
+    final todaysMissions = await MissionHistoryService.getTodaysMissions();
     setState(() {
       missions = todaysMissions;
     });
@@ -84,7 +84,8 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _toggleMissionComplete(String missionId) async {
-    final newState = await MissionService.toggleMissionComplete(missionId);
+    final newState =
+        await MissionHistoryService.toggleMissionComplete(missionId);
     setState(() {
       final updatedMissions = missions.map((mission) {
         if (mission.id == missionId) {

--- a/lib/services/mission_config_service.dart
+++ b/lib/services/mission_config_service.dart
@@ -6,9 +6,8 @@ import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:notiyou/repositories/mission_time_repository_local.dart';
 import 'package:notiyou/repositories/mission_time_repository_remote.dart';
 import 'package:notiyou/services/mission_alarm_service.dart';
-import 'package:notiyou/models/mission.dart';
 
-class MissionService {
+class MissionConfigService {
   static MissionTimeRepository _missionTimeRepository =
       MissionTimeRepositoryRemote();
   static MissionHistoryRepository _missionHistoryRepository =
@@ -47,47 +46,6 @@ class MissionService {
     final time = await _missionTimeRepository.getMissionTime(missionNumber);
 
     return time;
-  }
-
-  // 미션 완료 상태 토글 및 히스토리 저장
-  static Future<bool> toggleMissionComplete(String missionId) async {
-    final mission = await _missionHistoryRepository.findMissionById(missionId);
-
-    if (mission == null) {
-      throw Exception('Mission not found');
-    }
-
-    final newIsCompleted = !mission.isCompleted;
-    final updatedMission = mission.copyWith(
-      isCompleted: newIsCompleted,
-      completedAt: newIsCompleted ? DateTime.now() : null,
-    );
-
-    // 변경된 데이터 저장
-    await _missionHistoryRepository.updateMission(updatedMission);
-
-    // 변경된 미션의 새로운 상태 반환
-    return updatedMission.isCompleted;
-  }
-
-  static Future<bool> hasTodayMissions() async {
-    final missions =
-        await _missionHistoryRepository.findMissions(DateTime.now());
-    return missions.isNotEmpty;
-  }
-
-  // 오늘의 미션 데이터 가져오기
-  static Future<List<Mission>> getTodaysMissions() async {
-    final missions =
-        await _missionHistoryRepository.findMissions(DateTime.now());
-    print(missions);
-    // 저장된 미션 데이터 반환
-    return missions;
-  }
-
-  // 특정 날짜의 미션 히스토리 가져오기
-  static Future<List<Mission>> getMissionHistory(DateTime date) async {
-    return await _missionHistoryRepository.findMissions(date);
   }
 
   static switchToLocalRepository() {

--- a/lib/services/mission_history_service.dart
+++ b/lib/services/mission_history_service.dart
@@ -35,14 +35,6 @@ class MissionHistoryService {
     return updatedMission.isCompleted;
   }
 
-  // unused
-  @deprecated
-  static Future<bool> hasTodayMissions() async {
-    final missions =
-        await _missionHistoryRepository.findMissions(DateTime.now());
-    return missions.isNotEmpty;
-  }
-
   // 오늘의 미션 데이터 가져오기
   static Future<List<Mission>> getTodaysMissions() async {
     final missions =
@@ -50,13 +42,6 @@ class MissionHistoryService {
 
     // 저장된 미션 데이터 반환
     return missions;
-  }
-
-  // 특정 날짜의 미션 히스토리 가져오기
-  // unused
-  @deprecated
-  static Future<List<Mission>> getMissionHistory(DateTime date) async {
-    return await _missionHistoryRepository.findMissions(date);
   }
 
   static switchToLocalRepository() {

--- a/lib/services/mission_history_service.dart
+++ b/lib/services/mission_history_service.dart
@@ -47,7 +47,7 @@ class MissionHistoryService {
   static Future<List<Mission>> getTodaysMissions() async {
     final missions =
         await _missionHistoryRepository.findMissions(DateTime.now());
-    print(missions);
+
     // 저장된 미션 데이터 반환
     return missions;
   }

--- a/lib/services/mission_history_service.dart
+++ b/lib/services/mission_history_service.dart
@@ -1,9 +1,65 @@
+import 'package:notiyou/models/mission.dart';
 import 'package:notiyou/models/mission_history.dart';
 import 'package:notiyou/fixtures/mission_history.dart';
+import 'package:notiyou/repositories/mission_history_repository_interface.dart';
+import 'package:notiyou/repositories/mission_history_repository_local.dart';
+import 'package:notiyou/repositories/mission_history_repository_remote.dart';
 
 class MissionHistoryService {
+  static MissionHistoryRepository _missionHistoryRepository =
+      MissionHistoryRepositoryRemote();
+
   static Future<List<MissionHistory>> getMissionHistoriesByUserId(
       String userId) async {
     return missionHistoriesFixture;
+  }
+
+  // 미션 완료 상태 토글 및 히스토리 저장
+  static Future<bool> toggleMissionComplete(String missionId) async {
+    final mission = await _missionHistoryRepository.findMissionById(missionId);
+
+    if (mission == null) {
+      throw Exception('Mission not found');
+    }
+
+    final newIsCompleted = !mission.isCompleted;
+    final updatedMission = mission.copyWith(
+      isCompleted: newIsCompleted,
+      completedAt: newIsCompleted ? DateTime.now() : null,
+    );
+
+    // 변경된 데이터 저장
+    await _missionHistoryRepository.updateMission(updatedMission);
+
+    // 변경된 미션의 새로운 상태 반환
+    return updatedMission.isCompleted;
+  }
+
+  // unused
+  @deprecated
+  static Future<bool> hasTodayMissions() async {
+    final missions =
+        await _missionHistoryRepository.findMissions(DateTime.now());
+    return missions.isNotEmpty;
+  }
+
+  // 오늘의 미션 데이터 가져오기
+  static Future<List<Mission>> getTodaysMissions() async {
+    final missions =
+        await _missionHistoryRepository.findMissions(DateTime.now());
+    print(missions);
+    // 저장된 미션 데이터 반환
+    return missions;
+  }
+
+  // 특정 날짜의 미션 히스토리 가져오기
+  // unused
+  @deprecated
+  static Future<List<Mission>> getMissionHistory(DateTime date) async {
+    return await _missionHistoryRepository.findMissions(date);
+  }
+
+  static switchToLocalRepository() {
+    _missionHistoryRepository = MissionHistoryRepositoryLocal();
   }
 }

--- a/lib/services/mission_service.dart
+++ b/lib/services/mission_service.dart
@@ -1,22 +1,23 @@
 import 'package:flutter/material.dart';
-import 'package:notiyou/repositories/mission_repository_interface.dart';
-import 'package:notiyou/repositories/mission_repository_remote.dart';
+import 'package:notiyou/repositories/mission_history_repository_interface.dart';
+import 'package:notiyou/repositories/mission_history_repository_local.dart';
+import 'package:notiyou/repositories/mission_history_repository_remote.dart';
 import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:notiyou/repositories/mission_time_repository_local.dart';
 import 'package:notiyou/repositories/mission_time_repository_remote.dart';
 import 'package:notiyou/services/mission_alarm_service.dart';
 import 'package:notiyou/models/mission.dart';
-import 'package:notiyou/repositories/mission_repository_local.dart';
 
 class MissionService {
   static MissionTimeRepository _missionTimeRepository =
       MissionTimeRepositoryRemote();
-  static MissionRepository _missionRepository = MissionRepositoryRemote();
+  static MissionHistoryRepository _missionHistoryRepository =
+      MissionHistoryRepositoryRemote();
 
   // SharedPreferences 초기화
   static Future<void> init() async {
     await _missionTimeRepository.init();
-    await _missionRepository.init();
+    await _missionHistoryRepository.init();
   }
 
   // 미션 시간 저장
@@ -26,15 +27,16 @@ class MissionService {
   ) async {
     if (time != null) {
       await _missionTimeRepository.setMissionTime(missionNumber, time);
-      if (await _missionRepository.hasTodayMission(missionNumber)) {
-        await _missionRepository.updateTodayMissionTime(missionNumber, time);
+      if (await _missionHistoryRepository.hasTodayMission(missionNumber)) {
+        await _missionHistoryRepository.updateTodayMissionTime(
+            missionNumber, time);
       } else {
-        await _missionRepository.createTodayMission(missionNumber);
+        await _missionHistoryRepository.createTodayMission(missionNumber);
       }
     } else {
       await _missionTimeRepository.clearMissionTime(missionNumber);
       // 미션 시간 삭제시 오늘의 미션 삭제
-      await _missionRepository.removeTodayMission(missionNumber);
+      await _missionHistoryRepository.removeTodayMission(missionNumber);
     }
 
     await MissionAlarmService.updateAlarm(missionNumber, time);
@@ -49,7 +51,7 @@ class MissionService {
 
   // 미션 완료 상태 토글 및 히스토리 저장
   static Future<bool> toggleMissionComplete(String missionId) async {
-    final mission = await _missionRepository.findMissionById(missionId);
+    final mission = await _missionHistoryRepository.findMissionById(missionId);
 
     if (mission == null) {
       throw Exception('Mission not found');
@@ -62,32 +64,34 @@ class MissionService {
     );
 
     // 변경된 데이터 저장
-    await _missionRepository.updateMission(updatedMission);
+    await _missionHistoryRepository.updateMission(updatedMission);
 
     // 변경된 미션의 새로운 상태 반환
     return updatedMission.isCompleted;
   }
 
   static Future<bool> hasTodayMissions() async {
-    final missions = await _missionRepository.findMissions(DateTime.now());
+    final missions =
+        await _missionHistoryRepository.findMissions(DateTime.now());
     return missions.isNotEmpty;
   }
 
   // 오늘의 미션 데이터 가져오기
   static Future<List<Mission>> getTodaysMissions() async {
-    final missions = await _missionRepository.findMissions(DateTime.now());
-
+    final missions =
+        await _missionHistoryRepository.findMissions(DateTime.now());
+    print(missions);
     // 저장된 미션 데이터 반환
     return missions;
   }
 
   // 특정 날짜의 미션 히스토리 가져오기
   static Future<List<Mission>> getMissionHistory(DateTime date) async {
-    return await _missionRepository.findMissions(date);
+    return await _missionHistoryRepository.findMissions(date);
   }
 
   static switchToLocalRepository() {
     _missionTimeRepository = MissionTimeRepositoryLocal();
-    _missionRepository = MissionRepositoryLocal();
+    _missionHistoryRepository = MissionHistoryRepositoryLocal();
   }
 }


### PR DESCRIPTION
## 요약

mission_service 클래스와 관련하여 명칭, 책임과 관련한 개선 작업을 민철님과 함께 진행하였습니다.

## 작업 내용

- [refactor: supabase의 테이블 missions -> challenger_mission_time 변경 사항 대응](https://github.com/buku-buku/notiyou/pull/39/commits/0dbce71feb2511f9c8330b767f607a737b0926ee)
- [refactor: mission_repository -> mission_history_repository로 명칭 변경](https://github.com/buku-buku/notiyou/pull/39/commits/933e9127d5da33526b5d04a34fbf28c49268ccd4)
- [refactor: mission_service -> mission_config_service로 변경하고 일부 메서드를 mission_history_service로 이동](https://github.com/buku-buku/notiyou/pull/39/commits/7d17ea6b09aa03aeda4d11d6768b1cca4df8dc65)

- Supabase Table 수정
  - https://supabase.com/dashboard/project/pmiivbdkefsnzznxghwb/editor/40376?schema=public
