### PR TITLE
[NY-29] 도전자는 조력자를 초대할 수 있다 (안드로이드 App Links만)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,20 @@
           android:scheme="kakao${KAKAO_NATIVE_APP_KEY}"
         />
       </intent-filter>
+
+      <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data
+          android:scheme="https"
+          android:host="temp-web-link.vercel.app"
+          android:pathPattern="/invite/.*" />
+      </intent-filter>
+
+      <meta-data
+        android:name="flutter_deeplinking_enabled"
+        android:value="true" />
     </activity>
     <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/lib/widgets/supporter_section.dart
+++ b/lib/widgets/supporter_section.dart
@@ -86,17 +86,21 @@ class _SupporterSectionState extends State<SupporterSection>
         return;
       }
 
-      bool isKakaoTalkSharingAvailable =
-          await ShareClient.instance.isKakaoTalkSharingAvailable();
+      // TODO: user.id를 도전자 식별값으로 변경
+      final inviteLink = 'https://temp-web-link.vercel.app/invite/${user.id}';
+
       final TextTemplate defaultText = TextTemplate(
         objectType: 'text',
         text: '${user.id}님의 미션 서포터가 되어주시겠습니까?',
         buttonTitle: '동의하러 가기',
         link: Link(
-          webUrl: Uri.parse(''),
-          mobileWebUrl: Uri.parse(''),
+          webUrl: Uri.parse(inviteLink),
+          mobileWebUrl: Uri.parse(inviteLink),
         ),
       );
+
+      bool isKakaoTalkSharingAvailable =
+          await ShareClient.instance.isKakaoTalkSharingAvailable();
 
       if (isKakaoTalkSharingAvailable) {
         try {


### PR DESCRIPTION
## 요약
- 임시 웹페이지 vercel 배포
  - 도메인: https://temp-web-link.vercel.app/
  - 레포지토리: https://github.com/42KIM/temp-web-link
- 카카오톡 공유하기를 사용하여 조력자에게 초대링크를 전송하고,
  - 앱이 설치된 경우 App Link/Universal Link 처리 흐름 진행
  - 앱이 설치되지 않은 경우 temp-web-link를 거쳐 play store로 redirect (현재는 노티유가 스토어에 없기때문에 스토어 메인으로 연결)

## 작업 내용

- App Link / Universal Link 처리를 위한 임시 웹도메인 주소로 초대 링크 발송

## 기타 사항
- App Links 테스트 방법 By Cursor.ai
```
# 새 도메인에서 assetlinks.json 접근 확인
curl -v https://temp-web-link.vercel.app/.well-known/assetlinks.json

# App Links 재검증
adb shell pm verify-app-links --re-verify com.example.notiyou

# 상태 확인
adb shell pm get-app-links com.example.notiyou

# 테스트 실행
adb shell am start -W -a android.intent.action.VIEW \
    -d "https://temp-web-link.vercel.app/invite/123" \
    -c android.intent.category.BROWSABLE
```

## 체크리스트

- TODO: 임시 웹페이지 assetlinks.json에 사용된 DEBUG용 fingerprint를 release용으로 변경 필요