### PR TITLE
[NY-73] 기존의 회원가입 페이지를, 조력자 또는 도전자를 선택할 수 있는 페이지로 변경합니다.

### DIFF
--- a/lib/layouts/bottom_nav_layout.dart
+++ b/lib/layouts/bottom_nav_layout.dart
@@ -3,7 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_user.dart';
 import 'package:notiyou/screens/splash_page.dart';
 
-import 'package:notiyou/screens/config_page.dart';
+import 'package:notiyou/screens/challenger_config_page.dart';
 import 'package:notiyou/screens/history_page.dart';
 import 'package:notiyou/screens/home_page.dart';
 
@@ -33,7 +33,7 @@ class BottomNavLayout extends StatelessWidget {
   int _calculateSelectedIndex(BuildContext context) {
     final String location = GoRouterState.of(context).uri.path;
     if (location.startsWith(HomePage.routeName)) return 0;
-    if (location.startsWith(ConfigPage.routeName)) return 1;
+    if (location.startsWith(ChallengerConfigPage.routeName)) return 1;
     if (location.startsWith(HistoryPage.routeName)) return 2;
     return 0;
   }
@@ -68,7 +68,7 @@ class BottomNavLayout extends StatelessWidget {
               context.go(HomePage.routeName);
               break;
             case 1:
-              context.go(ConfigPage.routeName);
+              context.go(ChallengerConfigPage.routeName);
               break;
             case 2:
               context.go(HistoryPage.routeName);

--- a/lib/routes/index.dart
+++ b/lib/routes/index.dart
@@ -4,7 +4,7 @@ import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/screens/login_page.dart';
 import 'package:notiyou/screens/signup_page.dart';
-import 'package:notiyou/screens/config_page.dart';
+import 'package:notiyou/screens/challenger_config_page.dart';
 import 'package:notiyou/screens/history_page.dart';
 import 'package:notiyou/screens/splash_page.dart';
 
@@ -22,8 +22,8 @@ final routes = <RouteBase>[
     builder: (context, state) => const SignupPage(),
   ),
   GoRoute(
-    path: ConfigPage.onboardingRouteName,
-    builder: (context, state) => const ConfigPage(),
+    path: ChallengerConfigPage.onboardingRouteName,
+    builder: (context, state) => const ChallengerConfigPage(),
   ),
   ShellRoute(
     builder: (context, state, child) {
@@ -68,8 +68,8 @@ final List<GoRoute> bottomNavigationRoutes = [
     builder: (context, state) => const HistoryPage(),
   ),
   GoRoute(
-    path: ConfigPage.routeName,
-    builder: (context, state) => const ConfigPage(),
+    path: ChallengerConfigPage.routeName,
+    builder: (context, state) => const ChallengerConfigPage(),
   ),
 ];
 

--- a/lib/routes/index.dart
+++ b/lib/routes/index.dart
@@ -7,6 +7,7 @@ import 'package:notiyou/screens/signup_page.dart';
 import 'package:notiyou/screens/challenger_config_page.dart';
 import 'package:notiyou/screens/history_page.dart';
 import 'package:notiyou/screens/splash_page.dart';
+import 'package:notiyou/screens/supporter_signup_page.dart';
 
 final routes = <RouteBase>[
   GoRoute(
@@ -20,6 +21,12 @@ final routes = <RouteBase>[
   GoRoute(
     path: SignupPage.routeName,
     builder: (context, state) => const SignupPage(),
+  ),
+  GoRoute(
+    path: SupporterSignupPage.routeName,
+    builder: (context, state) => SupporterSignupPage(
+      initialChallengerCode: state.uri.queryParameters['code'],
+    ),
   ),
   GoRoute(
     path: ChallengerConfigPage.onboardingRouteName,

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -5,19 +5,19 @@ import 'package:notiyou/services/mission_config_service.dart';
 import 'package:notiyou/widgets/notification_template_config.dart';
 import 'package:notiyou/widgets/supporter_section.dart';
 
-class ConfigPage extends StatefulWidget {
-  static const String routeName = '/config';
-  static const String onboardingRouteName = '/config_onboarding';
+class ChallengerConfigPage extends StatefulWidget {
+  static const String routeName = '/challenger/config';
+  static const String onboardingRouteName = '/challenger/config_onboarding';
 
-  const ConfigPage({
+  const ChallengerConfigPage({
     super.key,
   });
 
   @override
-  State<ConfigPage> createState() => _ConfigPageState();
+  State<ChallengerConfigPage> createState() => _ChallengerConfigPageState();
 }
 
-class _ConfigPageState extends State<ConfigPage> {
+class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
   TimeOfDay? _mission1Time;
   TimeOfDay? _mission2Time;
 

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:notiyou/screens/config_page.dart';
+import 'package:notiyou/screens/challenger_config_page.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
 
@@ -25,7 +25,7 @@ class LoginPage extends StatelessWidget {
       if (registrationStatus['invitation_code'] != true) {
         context.go(SignupPage.routeName);
       } else if (registrationStatus['mission_setting'] != true) {
-        context.go(ConfigPage.onboardingRouteName);
+        context.go(ChallengerConfigPage.onboardingRouteName);
       } else {
         context.go(HomePage.routeName);
       }

--- a/lib/screens/signup_page.dart
+++ b/lib/screens/signup_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:notiyou/screens/config_page.dart';
+import 'package:notiyou/screens/challenger_config_page.dart';
+import 'package:notiyou/screens/supporter_signup_page.dart';
 
 class SignupPage extends StatelessWidget {
   const SignupPage({super.key});
@@ -10,22 +11,76 @@ class SignupPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Signup')),
+      appBar: AppBar(title: const Text('회원가입')),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const TextField(
-              decoration: InputDecoration(
-                labelText: '초대코드 입력',
+            const Text(
+              '당신의 역할을 선택해주세요',
+              style: TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
               ),
             ),
+            const SizedBox(height: 40),
+            _RoleSelectionButton(
+              title: '도전자',
+              subtitle: '목표를 달성하고 싶은 분',
+              onTap: () => context.go(ChallengerConfigPage.onboardingRouteName),
+            ),
             const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: () {
-                context.go(ConfigPage.onboardingRouteName);
-              },
-              child: const Text('완료'),
+            _RoleSelectionButton(
+              title: '조력자',
+              subtitle: '도전자를 응원하고 싶은 분',
+              onTap: () => context.go(SupporterSignupPage.routeName),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RoleSelectionButton extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  const _RoleSelectionButton({
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          border: Border.all(color: Theme.of(context).primaryColor),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              subtitle,
+              style: const TextStyle(
+                fontSize: 14,
+                color: Colors.grey,
+              ),
             ),
           ],
         ),

--- a/lib/screens/splash_page.dart
+++ b/lib/screens/splash_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:go_router/go_router.dart';
-import 'package:notiyou/screens/config_page.dart';
+import 'package:notiyou/screens/challenger_config_page.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/screens/login_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
@@ -35,7 +35,7 @@ class _SplashPageState extends State<SplashPage> {
       }
 
       if (registrationStatus['mission_setting'] != true) {
-        context.go(ConfigPage.onboardingRouteName);
+        context.go(ChallengerConfigPage.onboardingRouteName);
       } else {
         context.go(HomePage.routeName);
       }

--- a/lib/screens/supporter_signup_page.dart
+++ b/lib/screens/supporter_signup_page.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+class SupporterSignupPage extends StatelessWidget {
+  const SupporterSignupPage({
+    super.key,
+    this.initialChallengerCode,
+  });
+
+  static const String routeName = '/signup/supporter';
+  final String? initialChallengerCode;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('조력자 회원가입')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              '도전자의 코드를 입력해주세요',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              '도전자의 응원과 격려를 위해 코드가 필요합니다',
+              style: TextStyle(
+                color: Colors.grey,
+                fontSize: 14,
+              ),
+            ),
+            const SizedBox(height: 24),
+            TextField(
+              controller: TextEditingController(text: initialChallengerCode),
+              decoration: const InputDecoration(
+                labelText: '도전자 코드',
+                hintText: '도전자에게 받은 코드를 입력해주세요',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                // TODO: 도전자 코드 유효성 검사
+              },
+              child: const Text('다음'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/challenger_code/challenger_code_exception.dart
+++ b/lib/services/challenger_code/challenger_code_exception.dart
@@ -16,7 +16,9 @@ enum ChallengerCodeExceptionType {
   invalid('유효하지 않은 코드입니다'),
   notFound('존재하지 않는 도전자 코드입니다'),
   expired('만료된 코드입니다'),
-  alreadyUsed('이미 사용된 코드입니다');
+  alreadyUsed('이미 사용된 코드입니다'),
+  creationFailed('코드 생성에 실패했습니다'),
+  unknown('알 수 없는 오류');
 
   final String message;
   const ChallengerCodeExceptionType(this.message);

--- a/lib/services/challenger_code/challenger_code_exception.dart
+++ b/lib/services/challenger_code/challenger_code_exception.dart
@@ -1,0 +1,23 @@
+// 도전자 코드 검증 관련 에러 클래스
+// TODO: 다른 파일에서 관리
+class ChallengerCodeException implements Exception {
+  final String message;
+  final ChallengerCodeExceptionType type;
+
+  const ChallengerCodeException({
+    required this.message,
+    required this.type,
+  });
+}
+
+// 에러 타입 열거형
+enum ChallengerCodeExceptionType {
+  empty('코드를 입력해주세요'),
+  invalid('유효하지 않은 코드입니다'),
+  notFound('존재하지 않는 도전자 코드입니다'),
+  expired('만료된 코드입니다'),
+  alreadyUsed('이미 사용된 코드입니다');
+
+  final String message;
+  const ChallengerCodeExceptionType(this.message);
+}

--- a/lib/services/challenger_code/challenger_code_exception.dart
+++ b/lib/services/challenger_code/challenger_code_exception.dart
@@ -1,5 +1,3 @@
-// 도전자 코드 검증 관련 에러 클래스
-// TODO: 다른 파일에서 관리
 class ChallengerCodeException implements Exception {
   final String message;
   final ChallengerCodeExceptionType type;

--- a/lib/services/challenger_code/challenger_code_service.dart
+++ b/lib/services/challenger_code/challenger_code_service.dart
@@ -51,7 +51,7 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
         final index = (combinedNumber % radixBig).toInt();
         final safeIndex = index % _charset.length;
         codeChars[i] = _charset[safeIndex];
-        combinedNumber = combinedNumber >> 4;
+        combinedNumber = combinedNumber ~/ radixBig;
       }
 
       return codeChars.join();

--- a/lib/services/challenger_code/challenger_code_service.dart
+++ b/lib/services/challenger_code/challenger_code_service.dart
@@ -117,10 +117,10 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
     }
   }
 
-  int _codeToNumber(String code) {
-    var number = 0;
+  BigInt _codeToNumber(String code) {
+    var number = BigInt.from(0);
     for (var i = code.length - 1; i >= 0; i--) {
-      number = number * _radix + _charset.indexOf(code[i]);
+      number = number * BigInt.from(_radix) + BigInt.from(_charset.indexOf(code[i]));
     }
     return number;
   }

--- a/lib/services/challenger_code/challenger_code_service.dart
+++ b/lib/services/challenger_code/challenger_code_service.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
+import 'package:notiyou/services/challenger_code/challenger_code_exception.dart';
+import 'package:notiyou/services/challenger_code/challenger_code_service_interface.dart';
+import 'dart:math';
+
+class ChallengerCodeServiceImpl implements ChallengerCodeService {
+  ChallengerCodeServiceImpl._();
+  static final ChallengerCodeServiceImpl instance =
+      ChallengerCodeServiceImpl._();
+
+  static const _codeLength = 18;
+  static const _charset = '23456789ABCDEFGHJKLMNPQRSTUVWXYZ';
+  static const _radix = 34;
+
+  @override
+  Future<String> generateCode(String userId) async {
+    try {
+      if (userId.isEmpty) {
+        throw const ChallengerCodeException(
+          message: '사용자 ID를 입력해주세요',
+          type: ChallengerCodeExceptionType.creationFailed,
+        );
+      }
+
+      final userIdBytes = utf8.encode(userId);
+      final hash = sha256.convert(userIdBytes).bytes;
+
+      BigInt combinedNumber = BigInt.from(0);
+      for (var i = 0; i < 16; i++) {
+        combinedNumber = combinedNumber << 8;
+        combinedNumber += BigInt.from(hash[i]);
+      }
+
+      // 현재 시간 정보 추가 (마이크로초 단위까지)
+      final now = DateTime.now().microsecondsSinceEpoch;
+      combinedNumber += BigInt.from(now);
+
+      // 추가 엔트로피
+      final random = Random.secure();
+      for (var i = 0; i < 4; i++) {
+        combinedNumber = combinedNumber << 8;
+        combinedNumber += BigInt.from(random.nextInt(256));
+      }
+
+      // 코드 생성 (역순으로 생성)
+      final List<String> codeChars = List.filled(_codeLength, '');
+      final radixBig = BigInt.from(_radix);
+
+      for (var i = _codeLength - 1; i >= 0; i--) {
+        final index = (combinedNumber % radixBig).toInt();
+        final safeIndex = index % _charset.length;
+        codeChars[i] = _charset[safeIndex];
+        combinedNumber = combinedNumber >> 4;
+      }
+
+      return codeChars.join();
+    } catch (e) {
+      throw const ChallengerCodeException(
+        message: '도전자 코드 생성에 실패했습니다',
+        type: ChallengerCodeExceptionType.creationFailed,
+      );
+    }
+  }
+
+  @override
+  Future<void> verifyCode(String code) async {
+    try {
+      if (code.isEmpty) {
+        throw const ChallengerCodeException(
+          message: '도전자 코드를 입력해주세요',
+          type: ChallengerCodeExceptionType.empty,
+        );
+      }
+
+      if (code.length != _codeLength) {
+        throw const ChallengerCodeException(
+          message: '도전자 코드는 18자리여야 합니다',
+          type: ChallengerCodeExceptionType.invalid,
+        );
+      }
+
+      if (!code.split('').every((char) => _charset.contains(char))) {
+        throw const ChallengerCodeException(
+          message: '올바르지 않은 도전자 코드 형식입니다',
+          type: ChallengerCodeExceptionType.invalid,
+        );
+      }
+    } catch (e) {
+      if (e is ChallengerCodeException) rethrow;
+      throw const ChallengerCodeException(
+        message: '도전자 코드 검증에 실패했습니다',
+        type: ChallengerCodeExceptionType.unknown,
+      );
+    }
+  }
+
+  @override
+  Future<String> extractUserId(String code) async {
+    try {
+      await verifyCode(code);
+
+      // 코드를 숫자로 변환
+      final number = _codeToNumber(code);
+
+      // 숫자를 16진수 문자열로 변환 (userId 해시값으로 사용)
+      final hashHex = number.toRadixString(16).padLeft(8, '0');
+
+      // 이 해시값을 userId로 사용
+      return hashHex;
+    } catch (e) {
+      if (e is ChallengerCodeException) rethrow;
+      throw const ChallengerCodeException(
+        message: '사용자 ID 추출에 실패했습니다',
+        type: ChallengerCodeExceptionType.unknown,
+      );
+    }
+  }
+
+  int _codeToNumber(String code) {
+    var number = 0;
+    for (var i = code.length - 1; i >= 0; i--) {
+      number = number * _radix + _charset.indexOf(code[i]);
+    }
+    return number;
+  }
+}

--- a/lib/services/challenger_code/challenger_code_service_interface.dart
+++ b/lib/services/challenger_code/challenger_code_service_interface.dart
@@ -1,0 +1,5 @@
+abstract interface class ChallengerCodeService {
+  Future<String> generateCode(String userId);
+  Future<void> verifyCode(String code);
+  Future<String> extractUserId(String code);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -114,7 +114,7 @@ packages:
     source: hosted
     version: "3.1.2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   supabase_flutter: ^2.8.0
   intl: ^0.17.0
   flutter_native_splash: ^2.4.3
+  crypto: ^3.0.6
 
 dev_dependencies:
   flutter_test:

--- a/test/screens/signup_page_test.dart
+++ b/test/screens/signup_page_test.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:notiyou/screens/signup_page.dart';
 import 'package:notiyou/screens/challenger_config_page.dart';
+import 'package:notiyou/screens/supporter_signup_page.dart';
 
 class MockGoRouter extends Mock implements GoRouter {}
 
@@ -15,7 +16,7 @@ void main() {
       mockRouter = MockGoRouter();
     });
 
-    testWidgets('완료 버튼을 누르면 온보딩 모드로 설정 페이지로 이동한다', (tester) async {
+    testWidgets('도전자 회원가입 버튼을 누르면 온보딩 모드로 설정 페이지로 이동한다', (tester) async {
       when(() => mockRouter.go(any())).thenReturn(null);
 
       await tester.pumpWidget(
@@ -27,11 +28,29 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('완료'));
+      await tester.tap(find.text('도전자'));
       await tester.pumpAndSettle();
 
       verify(() => mockRouter.go(ChallengerConfigPage.onboardingRouteName))
           .called(1);
+    });
+
+    testWidgets('조력자 회원가입 버튼을 누르면 조력자 회원가입 페이지로 이동한다', (tester) async {
+      when(() => mockRouter.go(any())).thenReturn(null);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: InheritedGoRouter(
+            goRouter: mockRouter,
+            child: const SignupPage(),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('조력자'));
+      await tester.pumpAndSettle();
+
+      verify(() => mockRouter.go(SupporterSignupPage.routeName)).called(1);
     });
   });
 }

--- a/test/screens/signup_page_test.dart
+++ b/test/screens/signup_page_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:notiyou/screens/signup_page.dart';
-import 'package:notiyou/screens/config_page.dart';
+import 'package:notiyou/screens/challenger_config_page.dart';
 
 class MockGoRouter extends Mock implements GoRouter {}
 
@@ -30,7 +30,8 @@ void main() {
       await tester.tap(find.text('완료'));
       await tester.pumpAndSettle();
 
-      verify(() => mockRouter.go(ConfigPage.onboardingRouteName)).called(1);
+      verify(() => mockRouter.go(ChallengerConfigPage.onboardingRouteName))
+          .called(1);
     });
   });
 }

--- a/test/services/challenger_code/challenger_code_service_test.dart
+++ b/test/services/challenger_code/challenger_code_service_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:notiyou/services/challenger_code/challenger_code_exception.dart';
+import 'package:notiyou/services/challenger_code/challenger_code_service.dart';
+
+void main() {
+  late ChallengerCodeServiceImpl service;
+
+  setUp(() {
+    service = ChallengerCodeServiceImpl.instance;
+  });
+
+  group('ChallengerCodeService', () {
+    group('.generateCode()', () {
+      test('유효한 userId로 18자리 코드 생성', () async {
+        final code = await service.generateCode('test-user-id');
+
+        expect(code.length, 18);
+        expect(
+          code.split('').every(
+                (char) => '23456789ABCDEFGHJKLMNPQRSTUVWXYZ'.contains(char),
+              ),
+          true,
+        );
+      });
+
+      test('같은 userId로도 다른 시간에는 다른 코드 생성', () async {
+        final code1 = await service.generateCode('test-user-id');
+        await Future.delayed(const Duration(milliseconds: 100));
+        final code2 = await service.generateCode('test-user-id');
+
+        expect(code1, isNot(equals(code2)));
+      });
+
+      test('빈 userId로 코드 생성 시 예외 발생', () async {
+        expect(
+          () => service.generateCode(''),
+          throwsA(
+            isA<ChallengerCodeException>().having(
+              (e) => e.type,
+              'type',
+              ChallengerCodeExceptionType.creationFailed,
+            ),
+          ),
+        );
+      });
+    });
+
+    group('.verifyCode()', () {
+      test('유효한 코드 검증', () async {
+        final code = await service.generateCode('test-user-id');
+        await expectLater(service.verifyCode(code), completes);
+      });
+
+      test('빈 코드 검증 시 예외 발생', () async {
+        expect(
+          () => service.verifyCode(''),
+          throwsA(
+            isA<ChallengerCodeException>().having(
+              (e) => e.type,
+              'type',
+              ChallengerCodeExceptionType.empty,
+            ),
+          ),
+        );
+      });
+
+      test('잘못된 길이의 코드 검증 시 예외 발생', () async {
+        expect(
+          () => service.verifyCode('ABC'),
+          throwsA(
+            isA<ChallengerCodeException>().having(
+              (e) => e.type,
+              'type',
+              ChallengerCodeExceptionType.invalid,
+            ),
+          ),
+        );
+      });
+
+      test('잘못된 문자가 포함된 코드 검증 시 예외 발생', () async {
+        expect(
+          () => service.verifyCode('ABC1IO'),
+          throwsA(
+            isA<ChallengerCodeException>().having(
+              (e) => e.type,
+              'type',
+              ChallengerCodeExceptionType.invalid,
+            ),
+          ),
+        );
+      });
+    });
+
+    group('extractUserId 메서드', () {
+      test('생성된 코드에서 userId 해시값 추출', () async {
+        final code = await service.generateCode('test-user-id');
+        final extractedHash = await service.extractUserId(code);
+
+        expect(extractedHash, isNotEmpty);
+        expect(extractedHash.length, greaterThanOrEqualTo(8));
+      });
+
+      test('잘못된 코드로 userId 추출 시 예외 발생', () async {
+        expect(
+          () => service.extractUserId('INVALID'),
+          throwsA(isA<ChallengerCodeException>()),
+        );
+      });
+
+      test('빈 코드로 userId 추출 시 예외 발생', () async {
+        expect(
+          () => service.extractUserId(''),
+          throwsA(
+            isA<ChallengerCodeException>().having(
+              (e) => e.type,
+              'type',
+              ChallengerCodeExceptionType.empty,
+            ),
+          ),
+        );
+      });
+    });
+
+    test('전체 플로우 테스트', () async {
+      // 1. 코드 생성
+      final code = await service.generateCode('test-user-id');
+      expect(code.length, 18);
+
+      // 2. 코드 검증
+      await expectLater(service.verifyCode(code), completes);
+
+      // 3. userId 해시값 추출
+      final extractedHash = await service.extractUserId(code);
+      expect(extractedHash, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## 요약

기존의 회원가입 페이지를, 조력자 또는 도전자를 선택할 수 있는 페이지로 변경합니다.

## 작업 내용

Commits on Dec 31, 2024
- [refactor: config_page -> challenger_config_page로 변경](https://github.com/buku-buku/notiyou/pull/42/commits/e33bc9d2b772bc03acf8dcc54c5fceae63d6c8c0)
- [feat: 조력자 또는 도전자를 선택할 수 있는 signup_page 작성](https://github.com/buku-buku/notiyou/pull/42/commits/5a911e942a9784f82c97b1f4623a3ddd939a08df)
- [test: sign_up 페이지 테스트 케이스 수정](https://github.com/buku-buku/notiyou/pull/42/commits/2454567bd250d6df7a629d7dada1c375969687b1)

Commits on Jan 2, 2025
- [feat: 도전자 코드 유효성 검사에 대한 상태관리](https://github.com/buku-buku/notiyou/pull/42/commits/5b87cdba8c6d5d7fbb358b72a98076d2df14977b)

Commits on Jan 5, 2025
- [feat: 도전자 코드 생성 및 복호화 기능의 challenger_code_service 추가](https://github.com/buku-buku/notiyou/pull/42/commits/87d3668bd440a14637f6f7bedde9e46676038069)
- [refactor: 불필요 주석 제거](https://github.com/buku-buku/notiyou/pull/42/commits/30725c580256c594f26fda2bcf02f33c8e24333b)
- [feat: crypto 패키지 추가](https://github.com/buku-buku/notiyou/pull/42/commits/09b6e3a98a225e7940cded70fe29a657e0ee7df0)
- [fix: 34진수 변환 로직 오류 수정](https://github.com/buku-buku/notiyou/pull/42/commits/58a5722b3d3546664df737fde9867538b41632aa)

## 기타 사항

- 모든 유저가 도전자 또는 조력자에 상관 없이 앱을 설치하여 가입하는 시나리오로 변경됨에 따라, supabase에서 유저를 관리하는 구조를 변경하였습니다.
- 도전자, 조력자 테이블을 추가하고, 기존의 auth 테이블은 "카카오 인증"의 역할만을 수행합니다. 

<img width="993" alt="image" src="https://github.com/user-attachments/assets/175a536e-1f3f-4055-a603-1b1147ee09e5" />


## 체크리스트


## 스크린샷

| 회원가입 페이지 | 조력자 회원가입 페이지|
| -- | -- |
| <img width="463" alt="스크린샷 2024-12-31 오후 6 55 57" src="https://github.com/user-attachments/assets/72fa4e19-841a-40aa-b4fa-d5bab183dfec" /> | <img width="458" alt="스크린샷 2024-12-31 오후 7 01 23" src="https://github.com/user-attachments/assets/a5cc210a-8c54-4a4b-b10d-d6d998c42c7e" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
	- 사용자 역할 선택 기능 추가 (도전자/조력자)
	- 도전자 설정 페이지로 네비게이션 업데이트
	- 조력자 회원가입 페이지 도입

- **사용자 경험 개선**
	- 회원가입 프로세스 재설계
	- 직관적인 역할 선택 인터페이스 추가
	- 카카오 로그인 흐름 최적화

- **기타 변경사항**
	- UI 레이아웃 및 라우팅 구조 리팩토링
	- 일부 페이지 및 컴포넌트 이름 변경
	- 챌린저 코드 검증을 위한 새로운 예외 처리 추가
	- `crypto` 패키지 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->