### PR TITLE
[NY-96] feat: 회원가입 시나리오에 맞춰서 유저 정보에 역할을 저장하도록 설정

### DIFF
--- a/lib/models/registration_status.dart
+++ b/lib/models/registration_status.dart
@@ -1,0 +1,37 @@
+enum UserRole {
+  challenger,
+  supporter,
+  none; // 역할이 아직 지정되지 않은 경우
+
+  static UserRole fromString(String? value) {
+    if (value == null) return UserRole.none;
+    if (value.toLowerCase() == 'challenger') return UserRole.challenger;
+    if (value.toLowerCase() == 'supporter') return UserRole.supporter;
+    return UserRole.none;
+  }
+}
+
+class RegistrationStatus {
+  final UserRole registeredRole;
+
+  RegistrationStatus({
+    this.registeredRole = UserRole.none,
+  });
+
+  factory RegistrationStatus.fromString(String? value) {
+    return RegistrationStatus(
+      registeredRole: UserRole.fromString(value),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'registered_role': registeredRole.name,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'RegistrationStatus(registeredRole: $registeredRole)';
+  }
+}

--- a/lib/routes/index.dart
+++ b/lib/routes/index.dart
@@ -30,7 +30,9 @@ final routes = <RouteBase>[
   ),
   GoRoute(
     path: ChallengerConfigPage.onboardingRouteName,
-    builder: (context, state) => const ChallengerConfigPage(),
+    builder: (context, state) => const ChallengerConfigPage(
+      isFirstTime: true,
+    ),
   ),
   ShellRoute(
     builder: (context, state, child) {

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -111,7 +111,7 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
     if (widget.isFirstTime) {
       AuthService.setRole(UserRole.challenger);
     }
-    if (context.mounted) {
+    if (mounted) {
       context.go(HomePage.routeName);
     }
   }

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/screens/home_page.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:notiyou/services/mission_config_service.dart';
 import 'package:notiyou/widgets/notification_template_config.dart';
 import 'package:notiyou/widgets/supporter_section.dart';
@@ -9,8 +11,11 @@ class ChallengerConfigPage extends StatefulWidget {
   static const String routeName = '/challenger/config';
   static const String onboardingRouteName = '/challenger/config_onboarding';
 
+  final bool isFirstTime;
+
   const ChallengerConfigPage({
     super.key,
+    this.isFirstTime = false,
   });
 
   @override
@@ -100,6 +105,17 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
     );
   }
 
+  Future<void> _handleSubmit() async {
+    if (_mission1Time == null) return;
+    await _saveTimes();
+    if (widget.isFirstTime) {
+      AuthService.setRole(UserRole.challenger);
+    }
+    if (context.mounted) {
+      context.go(HomePage.routeName);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -168,14 +184,7 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
             ),
             const SizedBox(height: 20),
             ElevatedButton(
-              onPressed: _mission1Time != null
-                  ? () async {
-                      await _saveTimes();
-                      if (context.mounted) {
-                        context.go(HomePage.routeName);
-                      }
-                    }
-                  : null,
+              onPressed: _handleSubmit,
               child: const Text('설정 완료'),
             ),
           ],

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -105,8 +105,12 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
     );
   }
 
+  bool _isSubmittable() {
+    return _mission1Time != null;
+  }
+
   Future<void> _handleSubmit() async {
-    if (_mission1Time == null) return;
+    if (_isSubmittable() == false) return;
     await _saveTimes();
     if (widget.isFirstTime) {
       AuthService.setRole(UserRole.challenger);
@@ -184,7 +188,7 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
             ),
             const SizedBox(height: 20),
             ElevatedButton(
-              onPressed: _handleSubmit,
+              onPressed: _isSubmittable() ? _handleSubmit : null,
               child: const Text('설정 완료'),
             ),
           ],

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:notiyou/screens/challenger_config_page.dart';
+import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
 
@@ -22,10 +22,8 @@ class LoginPage extends StatelessWidget {
       if (!context.mounted) {
         return;
       }
-      if (registrationStatus['invitation_code'] != true) {
+      if (registrationStatus.registeredRole == UserRole.none) {
         context.go(SignupPage.routeName);
-      } else if (registrationStatus['mission_setting'] != true) {
-        context.go(ChallengerConfigPage.onboardingRouteName);
       } else {
         context.go(HomePage.routeName);
       }

--- a/lib/screens/splash_page.dart
+++ b/lib/screens/splash_page.dart
@@ -43,9 +43,9 @@ class _SplashPageState extends State<SplashPage> {
       if (mounted) {
         context.go(LoginPage.routeName);
       }
+    } finally {
+      FlutterNativeSplash.remove();
     }
-
-    FlutterNativeSplash.remove();
   }
 
   @override

--- a/lib/screens/splash_page.dart
+++ b/lib/screens/splash_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:go_router/go_router.dart';
-import 'package:notiyou/screens/challenger_config_page.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/screens/login_page.dart';
+import 'package:notiyou/screens/signup_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
 
 class SplashPage extends StatefulWidget {
@@ -29,15 +29,15 @@ class _SplashPageState extends State<SplashPage> {
         throw Exception('User not found');
       }
 
-      final registrationStatus = AuthService.getRegistrationStatus(user);
+      final isRegistrationComplete = AuthService.isRegistrationCompleted(user);
       if (!mounted) {
         return;
       }
 
-      if (registrationStatus['mission_setting'] != true) {
-        context.go(ChallengerConfigPage.onboardingRouteName);
-      } else {
+      if (isRegistrationComplete) {
         context.go(HomePage.routeName);
+      } else {
+        context.go(SignupPage.routeName);
       }
     } catch (error) {
       if (mounted) {

--- a/lib/screens/supporter_signup_page.dart
+++ b/lib/screens/supporter_signup_page.dart
@@ -74,12 +74,16 @@ class _SupporterSignupPageState extends State<SupporterSignupPage> {
     }
   }
 
-  void _onNextPressed() {
+  void _onNextPressed() async {
     final code = _challengerCodeController.text;
-    if (!_isValidated && !_validateChallengerCode(code)) {
+    if (!_isValidated && !await _validateChallengerCode(code)) {
       return;
     }
-    // TODO: 서버에서 도전자 코드 확인 후 다음 단계로 이동
+
+    // TODO: 도전자의 미션들의 서포터로 해당 유저를 등록
+
+    await AuthService.setRole(UserRole.supporter);
+
     debugPrint('도전자 코드 입력 완료: $code');
   }
 

--- a/lib/screens/supporter_signup_page.dart
+++ b/lib/screens/supporter_signup_page.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:notiyou/models/registration_status.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
 import 'dart:async';
 
 import 'package:notiyou/services/challenger_code/challenger_code_exception.dart';
+import 'package:notiyou/services/challenger_code/challenger_code_service.dart';
+import 'package:notiyou/services/challenger_code/challenger_code_service_interface.dart';
 
 class SupporterSignupPage extends StatefulWidget {
   const SupporterSignupPage({
@@ -18,6 +22,8 @@ class SupporterSignupPage extends StatefulWidget {
 
 class _SupporterSignupPageState extends State<SupporterSignupPage> {
   late final TextEditingController _challengerCodeController;
+  final ChallengerCodeService _challengerCodeService =
+      ChallengerCodeServiceImpl.instance;
   ChallengerCodeException? _error;
   Timer? _debounceTimer;
   bool _isValidated = false;
@@ -56,10 +62,9 @@ class _SupporterSignupPageState extends State<SupporterSignupPage> {
     });
   }
 
-  // TODO: ChallengerCodeService 클래스 구현 후 해당 클래스의 메서드 사용
-  bool _validateChallengerCode(String code) {
+  Future<bool> _validateChallengerCode(String code) async {
     try {
-      // TODO: ChallengerCodeService.validate(code) 메서드 호출
+      await _challengerCodeService.verifyCode(code);
       setState(() {
         _error = null;
         _isValidated = true;

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -1,4 +1,5 @@
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_talk.dart';
+import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/services/auth/kakao_auth_service.dart';
 import 'package:notiyou/services/auth/supabase_auth_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
@@ -43,8 +44,7 @@ class AuthService {
     return SupabaseAuthService.isRegistrationCompleted(user);
   }
 
-// TODO: RegistrationStatus 객체 정의
-  static Map<String, bool> getRegistrationStatus(supabase.User user) {
+  static RegistrationStatus getRegistrationStatus(supabase.User user) {
     return SupabaseAuthService.getRegistrationStatus(user);
   }
 }

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -36,6 +36,10 @@ class AuthService {
     }
   }
 
+  static Future<void> setRole(UserRole role) async {
+    return SupabaseAuthService.setRole(role);
+  }
+
   static Future<supabase.User?> getUser() async {
     return await SupabaseAuthService.getUser();
   }

--- a/lib/services/auth/supabase_auth_service.dart
+++ b/lib/services/auth/supabase_auth_service.dart
@@ -22,6 +22,7 @@ class SupabaseAuthService {
   static Future<void> setRole(UserRole role) async {
     final userMetadata =
         SupabaseService.client.auth.currentUser?.userMetadata ?? {};
+    // TODO: Add error handling for updateUser operation
     await SupabaseService.client.auth.updateUser(
       supabase.UserAttributes(
         data: {

--- a/lib/services/auth/supabase_auth_service.dart
+++ b/lib/services/auth/supabase_auth_service.dart
@@ -1,3 +1,4 @@
+import 'package:notiyou/models/registration_status.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 import 'package:notiyou/services/supabase_service.dart';
 
@@ -20,21 +21,18 @@ class SupabaseAuthService {
 
   static bool isRegistrationCompleted(supabase.User user) {
     final registrationStatus = getRegistrationStatus(user);
-    return registrationStatus['invitation_code'] == true &&
-        registrationStatus['mission_setting'] == true;
+    return registrationStatus.registeredRole != UserRole.none;
   }
 
-  static Map<String, bool> getRegistrationStatus(supabase.User user) {
+  static RegistrationStatus getRegistrationStatus(supabase.User user) {
     if (user.userMetadata == null) {
-      return {
-        'invitation_code': false,
-        'mission_setting': false,
-      };
+      return RegistrationStatus(
+        registeredRole: UserRole.none,
+      );
     }
-    // * 초대코드 및 미션 설정까지 입력 받아야 회원가입이 완료되었다고 판단할 수 있음
-    return {
-      'invitation_code': user.userMetadata!['invitation_code'] != null,
-      'mission_setting': user.userMetadata!['mission_setting'] != null,
-    };
+
+    return RegistrationStatus.fromString(
+      user.userMetadata!['registered_role'],
+    );
   }
 }

--- a/lib/services/auth/supabase_auth_service.dart
+++ b/lib/services/auth/supabase_auth_service.dart
@@ -19,6 +19,19 @@ class SupabaseAuthService {
     return SupabaseService.client.auth.currentUser;
   }
 
+  static Future<void> setRole(UserRole role) async {
+    final userMetadata =
+        SupabaseService.client.auth.currentUser?.userMetadata ?? {};
+    await SupabaseService.client.auth.updateUser(
+      supabase.UserAttributes(
+        data: {
+          ...userMetadata,
+          'registered_role': role.name,
+        },
+      ),
+    );
+  }
+
   static bool isRegistrationCompleted(supabase.User user) {
     final registrationStatus = getRegistrationStatus(user);
     return registrationStatus.registeredRole != UserRole.none;


### PR DESCRIPTION
## 요약

Supabase의 auth 테이블에서 유저 역할을 관리하도록 설정합니다. 해당 값에 따라 최초 앱 실행시 시나리오대로 페이지가 라우팅되게끔 처리합니다.

## 작업 내용

Commits on Jan 5, 2025
- [feat: RegistrationStatus 객체 통한 역할 결정 여부 확인 및 분기처리](https://github.com/buku-buku/notiyou/pull/43/commits/b90740b3e495f423692cdd916ef4e377359ef2d6)

Commits on Jan 7, 2025
- [feat: 유저 역할을 userMetadata에 저장할수 있는 메서드를 추가](https://github.com/buku-buku/notiyou/pull/43/commits/3f200785c6c16e6568e3c54aa33e485d6e8f2478)
- [feat: 최초로 challenger_config_page에서 설정 완료시 사용자 역할을 도전자로 저장](https://github.com/buku-buku/notiyou/pull/43/commits/3d4dd199713cc8fb7af878115728d7c5b5993eb5)
- [feat: 사용자가 조력자로서 도전자 코드 활성화시, 역할이 조력자가 되도록 설정](https://github.com/buku-buku/notiyou/pull/43/commits/426f4bbf4ca7ea6d72e4cfa825558a9d4c202adc)
- [feat: 도전자 코드 validation 기능 구현](https://github.com/buku-buku/notiyou/pull/43/commits/c06eacbeeb7cf4ba9cb15d7df9d2ba7a67c75176)

## 스크린샷

- 도전자 시나리오 
![화면 기록 2025-01-07 오후 7 50 04](https://github.com/user-attachments/assets/a62ff324-b6d6-4ca8-bb7e-c7c31575bcf0)

- 조력자 시나리오 
![화면 기록 2025-01-07 오후 7 52 29](https://github.com/user-attachments/assets/db662c25-ab29-47b4-903e-4a4ef42be153)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
  - 사용자 역할(challenger, supporter) 관리 기능 추가
  - 사용자 등록 상태 추적 시스템 개선
  - 첫 방문 사용자에 대한 역할 설정 기능 추가

- **개선 사항**
  - 로그인 및 회원가입 프로세스 최적화
  - 사용자 인증 및 권한 관리 로직 강화
  - 등록 상태 확인 및 탐색 흐름 간소화

- **버그 수정**
  - 사용자 등록 상태 확인 메커니즘 개선
  - 페이지 간 탐색 로직 안정화

이번 업데이트는 앱의 사용자 관리 및 인증 시스템을 더욱 효율적이고 안전하게 만들었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->