### PR TITLE
[NY-78] 도전자는 미션 유예 시간(구: 고자질 제한 시간)을 설정할 수 있다

### DIFF
--- a/lib/repositories/mission_grace_period_repository_interface.dart
+++ b/lib/repositories/mission_grace_period_repository_interface.dart
@@ -1,0 +1,4 @@
+abstract interface class MissionGracePeriodRepository {
+  Future<int> getGracePeriod();
+  Future<void> setGracePeriod(int gracePeriod);
+}

--- a/lib/repositories/mission_grace_period_repository_local.dart
+++ b/lib/repositories/mission_grace_period_repository_local.dart
@@ -1,0 +1,35 @@
+import 'package:notiyou/repositories/mission_grace_period_repository_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MissionGracePeriodRepositoryLocal
+    implements MissionGracePeriodRepository {
+  SharedPreferences? _prefs;
+
+  static final MissionGracePeriodRepositoryLocal _instance =
+      MissionGracePeriodRepositoryLocal._internal();
+
+  factory MissionGracePeriodRepositoryLocal() {
+    return _instance;
+  }
+
+  MissionGracePeriodRepositoryLocal._internal();
+
+  Future<void> init() async {
+    _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  @override
+  Future<int> getGracePeriod() async {
+    await init();
+    const key = 'grace_period';
+    final gracePeriod = _prefs!.getInt(key);
+    return gracePeriod ?? 0;
+  }
+
+  @override
+  Future<void> setGracePeriod(int gracePeriod) async {
+    await init();
+    const key = 'grace_period';
+    await _prefs!.setInt(key, gracePeriod);
+  }
+}

--- a/lib/repositories/mission_grace_period_repository_remote.dart
+++ b/lib/repositories/mission_grace_period_repository_remote.dart
@@ -1,0 +1,55 @@
+import 'package:notiyou/repositories/mission_grace_period_repository_interface.dart';
+import 'package:notiyou/services/supabase_service.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class MissionGracePeriodRepositoryRemote
+    implements MissionGracePeriodRepository {
+  static final MissionGracePeriodRepositoryRemote _instance =
+      MissionGracePeriodRepositoryRemote._internal();
+
+  factory MissionGracePeriodRepositoryRemote() {
+    return _instance;
+  }
+
+  MissionGracePeriodRepositoryRemote._internal();
+
+  static final supabaseClient = SupabaseService.client;
+
+  @override
+  Future<int> getGracePeriod() async {
+    final userId = supabaseClient.auth.currentUser?.id;
+    if (userId == null) {
+      throw const AuthException('User not found');
+    }
+
+    final gracePeriod = await supabaseClient
+        .from('challenger_grace_period')
+        .select('grace_period')
+        .eq('challenger_id', userId);
+
+    return gracePeriod.isNotEmpty ? gracePeriod.first['grace_period'] : 0;
+  }
+
+  @override
+  Future<void> setGracePeriod(int gracePeriod) async {
+    final userId = supabaseClient.auth.currentUser?.id;
+    if (userId == null) {
+      throw const AuthException('User not found');
+    }
+
+    final hasGracePeriod = await supabaseClient
+        .from('challenger_grace_period')
+        .select('id')
+        .eq('challenger_id', userId);
+
+    if (hasGracePeriod.isNotEmpty) {
+      await supabaseClient
+          .from('challenger_grace_period')
+          .update({'grace_period': gracePeriod}).eq('challenger_id', userId);
+    } else {
+      await supabaseClient
+          .from('challenger_grace_period')
+          .insert({'challenger_id': userId, 'grace_period': gracePeriod});
+    }
+  }
+}

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -188,7 +188,7 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
               title: const Text.rich(
                 TextSpan(
                   children: [
-                    TextSpan(text: '미션시간 1 '),
+                    TextSpan(text: '미션 시간 1 '),
                     TextSpan(
                       text: '(필수 선택)',
                       style: TextStyle(
@@ -218,7 +218,7 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
               ),
             ),
             ListTile(
-              title: const Text('미션시간 2'),
+              title: const Text('미션 시간 2'),
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -240,7 +240,7 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
             ListTile(
               title: Row(
                 children: [
-                  const Text('유예시간'),
+                  const Text('유예 시간'),
                   IconButton(
                     icon: const Icon(
                       Icons.help_outline,

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -40,8 +40,6 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
       MissionConfigService.getMissionTime(2),
     ]);
     setState(() {
-      // 병렬 처리
-
       _mission1Time = results[0];
       _mission2Time = results[1];
     });
@@ -55,7 +53,6 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
   }
 
   Future<void> _saveTimes() async {
-    // 시간이 변경되었는지 확인
     final bool hasTimeChanged =
         _mission1Time != await MissionConfigService.getMissionTime(1) ||
             _mission2Time != await MissionConfigService.getMissionTime(2) ||

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -26,6 +26,7 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
   TimeOfDay? _mission1Time;
   TimeOfDay? _mission2Time;
   int _selectedGracePeriod = 0;
+  bool _isSubmitLoading = false;
 
   @override
   void initState() {
@@ -119,6 +120,7 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
 
   Future<void> _handleSubmit() async {
     if (_isSubmittable() == false) return;
+    setState(() => _isSubmitLoading = true);
     await _saveTimes();
     if (widget.isFirstTime) {
       AuthService.setRole(UserRole.challenger);
@@ -126,6 +128,7 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
     if (mounted) {
       context.go(HomePage.routeName);
     }
+    setState(() => _isSubmitLoading = false);
   }
 
   Future<void> _showGracePeriodExplanation() async {
@@ -272,8 +275,25 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
             ),
             const SizedBox(height: 20),
             ElevatedButton(
-              onPressed: _isSubmittable() ? _handleSubmit : null,
-              child: const Text('설정 완료'),
+              onPressed:
+                  _isSubmittable() && !_isSubmitLoading ? _handleSubmit : null,
+              child: _isSubmitLoading
+                  ? const Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text('설정 완료'),
+                        SizedBox(width: 10),
+                        SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ],
+                    )
+                  : const Text('설정 완료'),
             ),
           ],
         ),

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -51,7 +51,7 @@ class _HomePageState extends State<HomePage> {
                 ),
               ListTile(
                 title: Text(
-                  '미션시간 ${mission.id} (${mission.time.format(context)})',
+                  '미션 시간 ${mission.id} (${mission.time.format(context)})',
                   style: TextStyle(
                     color: mission.expired ? Colors.red : null,
                   ),

--- a/lib/services/mission_config_service.dart
+++ b/lib/services/mission_config_service.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:notiyou/repositories/mission_grace_period_repository_remote.dart';
+import 'package:notiyou/repositories/mission_grace_period_repository_interface.dart';
+import 'package:notiyou/repositories/mission_grace_period_repository_local.dart';
 import 'package:notiyou/repositories/mission_history_repository_interface.dart';
 import 'package:notiyou/repositories/mission_history_repository_local.dart';
 import 'package:notiyou/repositories/mission_history_repository_remote.dart';
@@ -12,6 +15,8 @@ class MissionConfigService {
       MissionTimeRepositoryRemote();
   static MissionHistoryRepository _missionHistoryRepository =
       MissionHistoryRepositoryRemote();
+  static MissionGracePeriodRepository _missionGracePeriodRepository =
+      MissionGracePeriodRepositoryRemote();
 
   // SharedPreferences 초기화
   static Future<void> init() async {
@@ -48,8 +53,17 @@ class MissionConfigService {
     return time;
   }
 
+  static Future<int> getGracePeriod() async {
+    return await _missionGracePeriodRepository.getGracePeriod();
+  }
+
+  static Future<void> saveGracePeriod(int gracePeriod) async {
+    await _missionGracePeriodRepository.setGracePeriod(gracePeriod);
+  }
+
   static switchToLocalRepository() {
     _missionTimeRepository = MissionTimeRepositoryLocal();
     _missionHistoryRepository = MissionHistoryRepositoryLocal();
+    _missionGracePeriodRepository = MissionGracePeriodRepositoryLocal();
   }
 }


### PR DESCRIPTION
## 요약

도전자가 미션 유예 시간을 설정할 수 있는 기능을 추가합니다.

> [!Note]
>
> Q. 미션 유예 시간이란?
>
> 미션 유예 시간은(구: 고자질시간) 미션 시간 이후 미션을 완료하기까지 허용되는 추가 시간입니다. 예를 들어, 미션 시간이 오전 10시이고 유예 시간이 5분으로 설정된 경우, 오전 10시 5분까지 미션 완료를 기록하지 않으면 미션 실패로 간주하여 조력자에게 알림이 발송됩니다.

## 작업 내용


## 기타 사항



## 체크리스트



## 스크린샷


https://github.com/user-attachments/assets/9836d242-588a-4006-b1a1-2099a429ecd0


