### PR TITLE
[NY-101] 초대코드를 입력한 조력자 등록 처리

### DIFF
--- a/lib/repositories/mission_time_repository_interface.dart
+++ b/lib/repositories/mission_time_repository_interface.dart
@@ -7,7 +7,8 @@ abstract interface class MissionTimeRepository {
   Future<void> clearMissionTime(int missionNumber);
 }
 
-abstract interface class MissionSupporterRepository {
+abstract interface class MissionSupporterRepository
+    implements MissionTimeRepository {
   Future getMissionByUserId(String userId);
   Future<void> setMissionSupporter(String challengerId, String supporterId);
 }

--- a/lib/repositories/mission_time_repository_interface.dart
+++ b/lib/repositories/mission_time_repository_interface.dart
@@ -5,10 +5,6 @@ abstract interface class MissionTimeRepository {
   Future<TimeOfDay?> getMissionTime(int missionNumber);
   Future<void> setMissionTime(int missionNumber, TimeOfDay time);
   Future<void> clearMissionTime(int missionNumber);
-}
-
-abstract interface class MissionSupporterRepository
-    implements MissionTimeRepository {
   Future getMissionByUserId(String userId);
   Future<void> setMissionSupporter(String challengerId, String supporterId);
 }

--- a/lib/repositories/mission_time_repository_interface.dart
+++ b/lib/repositories/mission_time_repository_interface.dart
@@ -6,3 +6,8 @@ abstract interface class MissionTimeRepository {
   Future<void> setMissionTime(int missionNumber, TimeOfDay time);
   Future<void> clearMissionTime(int missionNumber);
 }
+
+abstract interface class MissionSupporterRepository {
+  Future getMissionByUserId(String userId);
+  Future<void> setMissionSupporter(String challengerId, String supporterId);
+}

--- a/lib/repositories/mission_time_repository_local.dart
+++ b/lib/repositories/mission_time_repository_local.dart
@@ -60,4 +60,11 @@ class MissionTimeRepositoryLocal implements MissionTimeRepository {
     final key = _getMissionKey(missionNumber);
     await _prefs!.remove(key);
   }
+
+  @override
+  Future getMissionByUserId(String userId) async {}
+
+  @override
+  Future<void> setMissionSupporter(
+      String challengerId, String supporterId) async {}
 }

--- a/lib/repositories/mission_time_repository_remote.dart
+++ b/lib/repositories/mission_time_repository_remote.dart
@@ -8,8 +8,7 @@ import 'package:notiyou/utils/time_utils.dart';
 ///
 /// 설정된 미션 시간은 서버에 기록되며, 서버에서 미션을 생성할때 사용됩니다.
 ///
-class MissionTimeRepositoryRemote
-    implements MissionTimeRepository, MissionSupporterRepository {
+class MissionTimeRepositoryRemote implements MissionTimeRepository {
   // 싱글턴 인스턴스
   static final MissionTimeRepositoryRemote _instance =
       MissionTimeRepositoryRemote._internal();

--- a/lib/repositories/mission_time_repository_remote.dart
+++ b/lib/repositories/mission_time_repository_remote.dart
@@ -8,7 +8,8 @@ import 'package:notiyou/utils/time_utils.dart';
 ///
 /// 설정된 미션 시간은 서버에 기록되며, 서버에서 미션을 생성할때 사용됩니다.
 ///
-class MissionTimeRepositoryRemote implements MissionTimeRepository {
+class MissionTimeRepositoryRemote
+    implements MissionTimeRepository, MissionSupporterRepository {
   // 싱글턴 인스턴스
   static final MissionTimeRepositoryRemote _instance =
       MissionTimeRepositoryRemote._internal();
@@ -43,6 +44,24 @@ class MissionTimeRepositoryRemote implements MissionTimeRepository {
     return mission.isNotEmpty
         ? TimeUtils.parseTime(mission.first['mission_at'])
         : null;
+  }
+
+  // TODO: 조력자와 미션(도전자)를 매칭하는 방식 개편 필요
+  @override
+  Future getMissionByUserId(String challengerId) async {
+    final mission = await supabaseClient
+        .from('challenger_mission_time')
+        .select('*')
+        .eq('challenger_id', challengerId);
+
+    return mission;
+  }
+
+  @override
+  Future<void> setMissionSupporter(
+      String challengerId, String supporterId) async {
+    await supabaseClient.from('challenger_mission_time').update(
+        {'supporter_id': supporterId}).eq('challenger_id', challengerId);
   }
 
   // 미션 시간 설정

--- a/lib/screens/supporter_signup_page.dart
+++ b/lib/screens/supporter_signup_page.dart
@@ -8,7 +8,7 @@ import 'dart:async';
 import 'package:notiyou/services/challenger_code/challenger_code_exception.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_service.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_service_interface.dart';
-import 'package:notiyou/services/mission_config_service.dart';
+import 'package:notiyou/services/mission_supporter_config_service.dart';
 import 'package:notiyou/services/mission_supporter_exception.dart';
 
 class SupporterSignupPage extends StatefulWidget {
@@ -90,7 +90,8 @@ class _SupporterSignupPageState extends State<SupporterSignupPage> {
     if (user == null) {
       throw Exception('User not found');
     }
-    await MissionConfigService.saveMissionSupporter(challengerId, user.id);
+    await MissionSupporterConfigService.saveMissionSupporter(
+        challengerId, user.id);
     await AuthService.setRole(UserRole.supporter);
   }
 

--- a/lib/services/invite_link_service.dart
+++ b/lib/services/invite_link_service.dart
@@ -54,12 +54,12 @@ class InviteLinkService {
 
   static Future<void> _handleLink(Uri uri) async {
     try {
-      String? parsedChallengerCode;
+      String? challengerCode;
       if (uri.scheme.startsWith('kakao')) {
         final uriString = uri.toString();
-        parsedChallengerCode = uriString.split('challenger_code=').last;
+        challengerCode = uriString.split('challenger_code=').last;
       } else if (uri.path.startsWith('/invite/')) {
-        parsedChallengerCode = uri.pathSegments.last;
+        challengerCode = uri.pathSegments.last;
       } else {
         throw Exception('올바른 초대링크가 아닙니다');
       }
@@ -67,10 +67,9 @@ class InviteLinkService {
       final userStatus = await _checkUserStatus();
       switch (userStatus) {
         case InvitedUserStatus.guest:
-          router.push(LoginPage.routeName, extra: parsedChallengerCode);
+          router.push(LoginPage.routeName, extra: challengerCode);
         case InvitedUserStatus.unregisteredUser:
-          router.push(SupporterSignupPage.routeName,
-              extra: parsedChallengerCode);
+          router.push(SupporterSignupPage.routeName, extra: challengerCode);
         case InvitedUserStatus.registeredUser:
           router.push(HomePage.routeName);
       }

--- a/lib/services/invite_link_service.dart
+++ b/lib/services/invite_link_service.dart
@@ -1,5 +1,4 @@
 import 'package:app_links/app_links.dart';
-import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/routes/router.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/screens/login_page.dart';
@@ -59,24 +58,22 @@ class InviteLinkService {
         throw Exception('올바른 초대링크가 아닙니다');
       }
 
-      final user = await AuthService.getUser();
-      if (user == null) {
-        router.push(
-          LoginPage.routeName,
-          extra: parsedChallengerCode,
-        );
-        return;
-      }
-
-      final registrationStatus = AuthService.getRegistrationStatus(user);
-      if (registrationStatus.registeredRole == UserRole.none) {
-        router.push(SupporterSignupPage.routeName, extra: parsedChallengerCode);
-        return;
-      }
-
-      router.push(HomePage.routeName);
+      _navigateUserByStatus(parsedChallengerCode);
     } catch (error) {
       _handleError('초대링크 처리 에러', error);
+    }
+  }
+
+  static Future<void> _navigateUserByStatus(
+      String? parsedChallengerCode) async {
+    final user = await AuthService.getUser();
+
+    if (user == null) {
+      router.push(LoginPage.routeName, extra: parsedChallengerCode);
+    } else if (AuthService.isRegistrationCompleted(user)) {
+      router.push(HomePage.routeName);
+    } else {
+      router.push(SupporterSignupPage.routeName, extra: parsedChallengerCode);
     }
   }
 

--- a/lib/services/mission_config_service.dart
+++ b/lib/services/mission_config_service.dart
@@ -9,13 +9,9 @@ import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:notiyou/repositories/mission_time_repository_local.dart';
 import 'package:notiyou/repositories/mission_time_repository_remote.dart';
 import 'package:notiyou/services/mission_alarm_service.dart';
-import 'package:notiyou/services/mission_supporter_exception.dart';
 
 class MissionConfigService {
-  static bool _isLocalMode = false;
   static MissionTimeRepository _missionTimeRepository =
-      MissionTimeRepositoryRemote();
-  static final MissionSupporterRepository _missionSupporterRepository =
       MissionTimeRepositoryRemote();
   static MissionHistoryRepository _missionHistoryRepository =
       MissionHistoryRepositoryRemote();
@@ -65,25 +61,7 @@ class MissionConfigService {
     await _missionGracePeriodRepository.setGracePeriod(gracePeriod);
   }
 
-  static Future<void> saveMissionSupporter(
-      String challengerId, String supporterId) async {
-    if (_isLocalMode) {
-      throw MissionSupporterException('오프라인 모드에서는 조력자 등록 기능을 사용할 수 없습니다.');
-    }
-    final mission =
-        await _missionSupporterRepository.getMissionByUserId(challengerId);
-    if (mission == null) {
-      throw MissionSupporterException('유효한 미션이 아닙니다.');
-    }
-    if (mission.supporterId != null) {
-      throw MissionSupporterException('추가 조력자를 등록할 수 없는 미션입니다.');
-    }
-    await _missionSupporterRepository.setMissionSupporter(
-        challengerId, supporterId);
-  }
-
   static switchToLocalRepository() {
-    _isLocalMode = true;
     _missionTimeRepository = MissionTimeRepositoryLocal();
     _missionHistoryRepository = MissionHistoryRepositoryLocal();
     _missionGracePeriodRepository = MissionGracePeriodRepositoryLocal();

--- a/lib/services/mission_config_service.dart
+++ b/lib/services/mission_config_service.dart
@@ -9,9 +9,13 @@ import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:notiyou/repositories/mission_time_repository_local.dart';
 import 'package:notiyou/repositories/mission_time_repository_remote.dart';
 import 'package:notiyou/services/mission_alarm_service.dart';
+import 'package:notiyou/services/mission_supporter_exception.dart';
 
 class MissionConfigService {
+  static bool _isLocalMode = false;
   static MissionTimeRepository _missionTimeRepository =
+      MissionTimeRepositoryRemote();
+  static final MissionSupporterRepository _missionSupporterRepository =
       MissionTimeRepositoryRemote();
   static MissionHistoryRepository _missionHistoryRepository =
       MissionHistoryRepositoryRemote();
@@ -61,7 +65,25 @@ class MissionConfigService {
     await _missionGracePeriodRepository.setGracePeriod(gracePeriod);
   }
 
+  static Future<void> saveMissionSupporter(
+      String challengerId, String supporterId) async {
+    if (_isLocalMode) {
+      throw MissionSupporterException('오프라인 모드에서는 조력자 등록 기능을 사용할 수 없습니다.');
+    }
+    final mission =
+        await _missionSupporterRepository.getMissionByUserId(challengerId);
+    if (mission == null) {
+      throw MissionSupporterException('유효한 미션이 아닙니다.');
+    }
+    if (mission.supporterId != null) {
+      throw MissionSupporterException('추가 조력자를 등록할 수 없는 미션입니다.');
+    }
+    await _missionSupporterRepository.setMissionSupporter(
+        challengerId, supporterId);
+  }
+
   static switchToLocalRepository() {
+    _isLocalMode = true;
     _missionTimeRepository = MissionTimeRepositoryLocal();
     _missionHistoryRepository = MissionHistoryRepositoryLocal();
     _missionGracePeriodRepository = MissionGracePeriodRepositoryLocal();

--- a/lib/services/mission_supporter_config_service.dart
+++ b/lib/services/mission_supporter_config_service.dart
@@ -1,10 +1,11 @@
 import 'package:notiyou/repositories/mission_time_repository_interface.dart';
+import 'package:notiyou/repositories/mission_time_repository_local.dart';
 import 'package:notiyou/repositories/mission_time_repository_remote.dart';
 import 'package:notiyou/services/mission_supporter_exception.dart';
 
 class MissionSupporterConfigService {
   static bool _isLocalMode = false;
-  static final MissionSupporterRepository _missionTimeRepository =
+  static MissionTimeRepository _missionTimeRepository =
       MissionTimeRepositoryRemote();
 
   static Future<void> init() async {
@@ -29,5 +30,6 @@ class MissionSupporterConfigService {
 
   static switchToLocalRepository() {
     _isLocalMode = true;
+    _missionTimeRepository = MissionTimeRepositoryLocal();
   }
 }

--- a/lib/services/mission_supporter_config_service.dart
+++ b/lib/services/mission_supporter_config_service.dart
@@ -1,0 +1,33 @@
+import 'package:notiyou/repositories/mission_time_repository_interface.dart';
+import 'package:notiyou/repositories/mission_time_repository_remote.dart';
+import 'package:notiyou/services/mission_supporter_exception.dart';
+
+class MissionSupporterConfigService {
+  static bool _isLocalMode = false;
+  static final MissionSupporterRepository _missionTimeRepository =
+      MissionTimeRepositoryRemote();
+
+  static Future<void> init() async {
+    await _missionTimeRepository.init();
+  }
+
+  static Future<void> saveMissionSupporter(
+      String challengerId, String supporterId) async {
+    if (_isLocalMode) {
+      throw MissionSupporterException('오프라인 모드에서는 조력자 등록 기능을 사용할 수 없습니다.');
+    }
+    final mission =
+        await _missionTimeRepository.getMissionByUserId(challengerId);
+    if (mission == null) {
+      throw MissionSupporterException('유효한 미션이 아닙니다.');
+    }
+    if (mission.supporterId != null) {
+      throw MissionSupporterException('추가 조력자를 등록할 수 없는 미션입니다.');
+    }
+    await _missionTimeRepository.setMissionSupporter(challengerId, supporterId);
+  }
+
+  static switchToLocalRepository() {
+    _isLocalMode = true;
+  }
+}

--- a/lib/services/mission_supporter_exception.dart
+++ b/lib/services/mission_supporter_exception.dart
@@ -1,0 +1,4 @@
+class MissionSupporterException implements Exception {
+  final String message;
+  MissionSupporterException(this.message);
+}


### PR DESCRIPTION
## 요약
- 조력자가 초대코드를 입력하면, 유효성 검사 후 조력자를 도전자의 미션에 등록합니다
- 완료 후 Home 페이지로 이동시킵니다

## 작업 내용
- [refactor: 초대된 조력자 라우팅 처리 조건문 가독성 개선](https://github.com/buku-buku/notiyou/pull/53/commits/46b82b5265b288a096ab18cf0d22686fe5694f61)
- [feat: mission config service에 서포터 관련 로직 추가](https://github.com/buku-buku/notiyou/pull/53/commits/f0f23a4eaf9bd37fb6b994bc4f0cf6cf66020d37)
  - 서포터 등록 관련 MissionTimeRepository에 필요한 interface, exception 등 추가
- [feat: 도전자를 미션에 할당하는 기능 추가](https://github.com/buku-buku/notiyou/pull/53/commits/5b2d96f93761cac8effcb79caac6784e99056865)
  - 초대코드 입력 후 서포터 등록 진행

## 기타 사항
🚨 extract id 기능 수정 전까지는 실제로 서포터가 등록되지 않습니다.
🚨 현재 방식에서는 challenger가 한 개 이상의 미션을 보유한 경우 정상적으로 조력자가 매칭되지 않습니다. getMissionByUserId가 오직 challengerId로만 row를 select하기 때문



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 미션 지원자 등록 프로세스가 개선되어, 지원자 역할 등록 및 오류 처리가 강화되었습니다.
  - 초대 링크를 통한 사용자 안내가 개선되어, 게스트, 미가입자, 등록 사용자에 맞춰 각각 로그인, 회원가입, 또는 홈 화면으로 자동 전환됩니다.
  - 오프라인 모드에서 미션 지원자 등록 기능이 제한되어, 적절한 안내와 예외 처리가 추가되었습니다.
  - 미션 데이터에 대한 사용자 ID 기반 검색 기능이 추가되었습니다.
  - 미션 지원자 설정 기능이 추가되어, 챌린저 ID에 따라 지원자를 등록할 수 있게 되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->