### PR TITLE
[NY-104] extractUserId 메서드가 동작하지 않는 문제 수정

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - app_links (0.0.2):
+  - app_links (0.0.1):
     - Flutter
   - Flutter (1.0.0)
   - flutter_local_notifications (0.0.1):
@@ -52,7 +52,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  app_links: e7a6750a915a9e161c58d91bc610e8cd1d4d0ad0
+  app_links: e70ca16b4b0f88253b3b3660200d4a10b4ea9795
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_local_notifications: df98d66e515e1ca797af436137b4459b160ad8c9
   flutter_native_splash: e8a1e01082d97a8099d973f919f57904c925008a

--- a/lib/services/challenger_code/challenger_code_exception.dart
+++ b/lib/services/challenger_code/challenger_code_exception.dart
@@ -1,11 +1,27 @@
 class ChallengerCodeException implements Exception {
   final String message;
   final ChallengerCodeExceptionType type;
+  final String? details;
 
   const ChallengerCodeException({
     required this.message,
     required this.type,
+    this.details,
   });
+
+  @override
+  String toString() {
+    final buffer = StringBuffer()
+      ..writeln('ChallengerCodeException:')
+      ..writeln('  Type: $type')
+      ..writeln('  Message: $message');
+
+    if (details != null) {
+      buffer.writeln('  Details: $details');
+    }
+
+    return buffer.toString();
+  }
 }
 
 // 에러 타입 열거형

--- a/lib/services/challenger_code/challenger_code_service.dart
+++ b/lib/services/challenger_code/challenger_code_service.dart
@@ -32,9 +32,10 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
       // URL 안전한 base64로 인코딩 ('+' -> '-', '/' -> '_', '=' 제거)
       return base64Url.encode(encrypted.bytes);
     } catch (e) {
-      throw const ChallengerCodeException(
+      throw ChallengerCodeException(
         message: '도전자 코드 생성에 실패했습니다',
         type: ChallengerCodeExceptionType.creationFailed,
+        details: e.toString(),
       );
     }
   }
@@ -64,9 +65,10 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
       return decrypted;
     } catch (e) {
       if (e is ChallengerCodeException) rethrow;
-      throw const ChallengerCodeException(
+      throw ChallengerCodeException(
         message: '사용자 ID 추출에 실패했습니다',
         type: ChallengerCodeExceptionType.unknown,
+        details: e.toString(),
       );
     }
   }

--- a/lib/services/challenger_code/challenger_code_service.dart
+++ b/lib/services/challenger_code/challenger_code_service.dart
@@ -12,9 +12,6 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
   // 테스트용 고정 키
   static final _key =
       encrypt.Key.fromBase64(DotEnvService.getValue('CHALLENGER_CODE_KEY'));
-  // 테스트용 고정 IV
-  static final _iv =
-      encrypt.IV.fromBase64(DotEnvService.getValue('CHALLENGER_CODE_IV'));
 
   @override
   Future<String> generateCode(String userId) async {
@@ -27,7 +24,7 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
       }
 
       final encrypter = encrypt.Encrypter(encrypt.AES(_key));
-      final encrypted = encrypter.encrypt(userId, iv: _iv);
+      final encrypted = encrypter.encrypt(userId);
 
       // URL 안전한 base64로 인코딩 ('+' -> '-', '/' -> '_', '=' 제거)
       return base64Url.encode(encrypted.bytes);
@@ -57,10 +54,7 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
       final bytes = base64Url.decode(code);
 
       // 복호화
-      final decrypted = encrypter.decrypt(
-        encrypt.Encrypted(bytes),
-        iv: _iv,
-      );
+      final decrypted = encrypter.decrypt(encrypt.Encrypted(bytes));
 
       return decrypted;
     } catch (e) {

--- a/lib/services/challenger_code/challenger_code_service.dart
+++ b/lib/services/challenger_code/challenger_code_service.dart
@@ -79,5 +79,14 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
         type: ChallengerCodeExceptionType.empty,
       );
     }
+    try {
+      await extractUserId(code);
+    } catch (e) {
+      throw ChallengerCodeException(
+        message: '도전자 코드 검증에 실패했습니다',
+        type: ChallengerCodeExceptionType.invalid,
+        details: e.toString(),
+      );
+    }
   }
 }

--- a/lib/services/challenger_code/challenger_code_service.dart
+++ b/lib/services/challenger_code/challenger_code_service.dart
@@ -1,17 +1,20 @@
+import 'package:encrypt/encrypt.dart' as encrypt;
 import 'dart:convert';
-import 'package:crypto/crypto.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_exception.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_service_interface.dart';
-import 'dart:math';
+import 'package:notiyou/services/dotenv_service.dart';
 
 class ChallengerCodeServiceImpl implements ChallengerCodeService {
   ChallengerCodeServiceImpl._();
   static final ChallengerCodeServiceImpl instance =
       ChallengerCodeServiceImpl._();
 
-  static const _codeLength = 18;
-  static const _charset = '23456789ABCDEFGHJKLMNPQRSTUVWXYZ';
-  static const _radix = 34;
+  // 테스트용 고정 키
+  static final _key =
+      encrypt.Key.fromBase64(DotEnvService.getValue('CHALLENGER_CODE_KEY'));
+  // 테스트용 고정 IV
+  static final _iv =
+      encrypt.IV.fromBase64(DotEnvService.getValue('CHALLENGER_CODE_IV'));
 
   @override
   Future<String> generateCode(String userId) async {
@@ -23,38 +26,11 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
         );
       }
 
-      final userIdBytes = utf8.encode(userId);
-      final hash = sha256.convert(userIdBytes).bytes;
+      final encrypter = encrypt.Encrypter(encrypt.AES(_key));
+      final encrypted = encrypter.encrypt(userId, iv: _iv);
 
-      BigInt combinedNumber = BigInt.from(0);
-      for (var i = 0; i < 16; i++) {
-        combinedNumber = combinedNumber << 8;
-        combinedNumber += BigInt.from(hash[i]);
-      }
-
-      // 현재 시간 정보 추가 (마이크로초 단위까지)
-      final now = DateTime.now().microsecondsSinceEpoch;
-      combinedNumber += BigInt.from(now);
-
-      // 추가 엔트로피
-      final random = Random.secure();
-      for (var i = 0; i < 4; i++) {
-        combinedNumber = combinedNumber << 8;
-        combinedNumber += BigInt.from(random.nextInt(256));
-      }
-
-      // 코드 생성 (역순으로 생성)
-      final List<String> codeChars = List.filled(_codeLength, '');
-      final radixBig = BigInt.from(_radix);
-
-      for (var i = _codeLength - 1; i >= 0; i--) {
-        final index = (combinedNumber % radixBig).toInt();
-        final safeIndex = index % _charset.length;
-        codeChars[i] = _charset[safeIndex];
-        combinedNumber = combinedNumber ~/ radixBig;
-      }
-
-      return codeChars.join();
+      // URL 안전한 base64로 인코딩 ('+' -> '-', '/' -> '_', '=' 제거)
+      return base64Url.encode(encrypted.bytes);
     } catch (e) {
       throw const ChallengerCodeException(
         message: '도전자 코드 생성에 실패했습니다',
@@ -64,7 +40,7 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
   }
 
   @override
-  Future<void> verifyCode(String code) async {
+  Future<String> extractUserId(String code) async {
     try {
       if (code.isEmpty) {
         throw const ChallengerCodeException(
@@ -73,41 +49,19 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
         );
       }
 
-      if (code.length != _codeLength) {
-        throw const ChallengerCodeException(
-          message: '도전자 코드는 18자리여야 합니다',
-          type: ChallengerCodeExceptionType.invalid,
-        );
-      }
+      // AES 복호화 설정
+      final encrypter = encrypt.Encrypter(encrypt.AES(_key));
 
-      if (!code.split('').every((char) => _charset.contains(char))) {
-        throw const ChallengerCodeException(
-          message: '올바르지 않은 도전자 코드 형식입니다',
-          type: ChallengerCodeExceptionType.invalid,
-        );
-      }
-    } catch (e) {
-      if (e is ChallengerCodeException) rethrow;
-      throw const ChallengerCodeException(
-        message: '도전자 코드 검증에 실패했습니다',
-        type: ChallengerCodeExceptionType.unknown,
+      // URL 안전한 base64 디코딩
+      final bytes = base64Url.decode(code);
+
+      // 복호화
+      final decrypted = encrypter.decrypt(
+        encrypt.Encrypted(bytes),
+        iv: _iv,
       );
-    }
-  }
 
-  @override
-  Future<String> extractUserId(String code) async {
-    try {
-      await verifyCode(code);
-
-      // 코드를 숫자로 변환
-      final number = _codeToNumber(code);
-
-      // 숫자를 16진수 문자열로 변환 (userId 해시값으로 사용)
-      final hashHex = number.toRadixString(16).padLeft(8, '0');
-
-      // 이 해시값을 userId로 사용
-      return hashHex;
+      return decrypted;
     } catch (e) {
       if (e is ChallengerCodeException) rethrow;
       throw const ChallengerCodeException(
@@ -117,12 +71,13 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
     }
   }
 
-  BigInt _codeToNumber(String code) {
-    var number = BigInt.from(0);
-    for (var i = code.length - 1; i >= 0; i--) {
-      number =
-          number * BigInt.from(_radix) + BigInt.from(_charset.indexOf(code[i]));
+  @override
+  Future<void> verifyCode(String code) async {
+    if (code.isEmpty) {
+      throw const ChallengerCodeException(
+        message: '도전자 코드를 입력해주세요',
+        type: ChallengerCodeExceptionType.empty,
+      );
     }
-    return number;
   }
 }

--- a/lib/services/challenger_code/challenger_code_service.dart
+++ b/lib/services/challenger_code/challenger_code_service.dart
@@ -12,6 +12,9 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
   // 테스트용 고정 키
   static final _key =
       encrypt.Key.fromBase64(DotEnvService.getValue('CHALLENGER_CODE_KEY'));
+  // 테스트용 고정 IV
+  static final _iv =
+      encrypt.IV.fromBase64(DotEnvService.getValue('CHALLENGER_CODE_IV'));
 
   @override
   Future<String> generateCode(String userId) async {
@@ -24,7 +27,7 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
       }
 
       final encrypter = encrypt.Encrypter(encrypt.AES(_key));
-      final encrypted = encrypter.encrypt(userId);
+      final encrypted = encrypter.encrypt(userId, iv: _iv);
 
       // URL 안전한 base64로 인코딩 ('+' -> '-', '/' -> '_', '=' 제거)
       return base64Url.encode(encrypted.bytes);
@@ -54,7 +57,10 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
       final bytes = base64Url.decode(code);
 
       // 복호화
-      final decrypted = encrypter.decrypt(encrypt.Encrypted(bytes));
+      final decrypted = encrypter.decrypt(
+        encrypt.Encrypted(bytes),
+        iv: _iv,
+      );
 
       return decrypted;
     } catch (e) {

--- a/lib/services/dotenv_service.dart
+++ b/lib/services/dotenv_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:meta/meta.dart';
 
 class DotEnvService {
   static Future<void> init() async {
@@ -14,5 +15,15 @@ class DotEnvService {
       throw Exception('Key $key not found in .env file');
     }
     return value;
+  }
+
+  @visibleForTesting
+  static void mockValue(String key, String value) {
+    dotenv.env[key] = value;
+  }
+
+  @visibleForTesting
+  static void resetMocks() {
+    dotenv.env.clear();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -449,7 +449,7 @@ packages:
     source: hosted
     version: "0.11.1"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -130,7 +130,7 @@ packages:
     source: hosted
     version: "2.0.0"
   encrypt:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: encrypt
       sha256: "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter_native_splash: ^2.4.3
   app_links: ^3.5.0
   crypto: ^3.0.6
+  encrypt: ^5.0.3
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   app_links: ^3.5.0
   crypto: ^3.0.6
   encrypt: ^5.0.3
+  meta: ^1.15.0
 
 dev_dependencies:
   flutter_test:

--- a/test/services/challenger_code/challenger_code_service_test.dart
+++ b/test/services/challenger_code/challenger_code_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:encrypt/encrypt.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_exception.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_service.dart';
@@ -9,6 +10,10 @@ void main() {
 
   setUp(() async {
     await DotEnvService.init();
+    final secretKey = Encrypted.fromSecureRandom(32).base64;
+    final iv = Encrypted.fromSecureRandom(16).base64;
+    DotEnvService.mockValue('CHALLENGER_CODE_KEY', secretKey);
+    DotEnvService.mockValue('CHALLENGER_CODE_IV', iv);
     service = ChallengerCodeServiceImpl.instance;
   });
 

--- a/test/services/challenger_code/challenger_code_service_test.dart
+++ b/test/services/challenger_code/challenger_code_service_test.dart
@@ -1,34 +1,24 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_exception.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_service.dart';
+import 'package:notiyou/services/dotenv_service.dart';
 
 void main() {
   late ChallengerCodeServiceImpl service;
+  const testUserId = 'a0ce3149-4aac-4416-be09-1ca5424dd9d5';
 
-  setUp(() {
+  setUp(() async {
+    await DotEnvService.init();
     service = ChallengerCodeServiceImpl.instance;
   });
 
   group('ChallengerCodeService', () {
     group('.generateCode()', () {
-      test('유효한 userId로 18자리 코드 생성', () async {
-        final code = await service.generateCode('test-user-id');
+      test('유효한 userId로 암호화된 코드 생성', () async {
+        final code = await service.generateCode(testUserId);
 
-        expect(code.length, 18);
-        expect(
-          code.split('').every(
-                (char) => '23456789ABCDEFGHJKLMNPQRSTUVWXYZ'.contains(char),
-              ),
-          true,
-        );
-      });
-
-      test('같은 userId로도 다른 시간에는 다른 코드 생성', () async {
-        final code1 = await service.generateCode('test-user-id');
-        await Future.delayed(const Duration(milliseconds: 100));
-        final code2 = await service.generateCode('test-user-id');
-
-        expect(code1, isNot(equals(code2)));
+        expect(code, isNotEmpty);
+        expect(code, isA<String>());
       });
 
       test('빈 userId로 코드 생성 시 예외 발생', () async {
@@ -47,7 +37,7 @@ void main() {
 
     group('.verifyCode()', () {
       test('유효한 코드 검증', () async {
-        final code = await service.generateCode('test-user-id');
+        final code = await service.generateCode(testUserId);
         await expectLater(service.verifyCode(code), completes);
       });
 
@@ -63,46 +53,19 @@ void main() {
           ),
         );
       });
-
-      test('잘못된 길이의 코드 검증 시 예외 발생', () async {
-        expect(
-          () => service.verifyCode('ABC'),
-          throwsA(
-            isA<ChallengerCodeException>().having(
-              (e) => e.type,
-              'type',
-              ChallengerCodeExceptionType.invalid,
-            ),
-          ),
-        );
-      });
-
-      test('잘못된 문자가 포함된 코드 검증 시 예외 발생', () async {
-        expect(
-          () => service.verifyCode('ABC1IO'),
-          throwsA(
-            isA<ChallengerCodeException>().having(
-              (e) => e.type,
-              'type',
-              ChallengerCodeExceptionType.invalid,
-            ),
-          ),
-        );
-      });
     });
 
     group('extractUserId 메서드', () {
-      test('생성된 코드에서 userId 해시값 추출', () async {
-        final code = await service.generateCode('test-user-id');
-        final extractedHash = await service.extractUserId(code);
+      test('생성된 코드에서 userId 추출', () async {
+        final code = await service.generateCode(testUserId);
+        final extractedUserId = await service.extractUserId(code);
 
-        expect(extractedHash, isNotEmpty);
-        expect(extractedHash.length, greaterThanOrEqualTo(8));
+        expect(extractedUserId, testUserId);
       });
 
       test('잘못된 코드로 userId 추출 시 예외 발생', () async {
         expect(
-          () => service.extractUserId('INVALID'),
+          () => service.extractUserId('INVALID_CODE'),
           throwsA(isA<ChallengerCodeException>()),
         );
       });
@@ -123,15 +86,15 @@ void main() {
 
     test('전체 플로우 테스트', () async {
       // 1. 코드 생성
-      final code = await service.generateCode('test-user-id');
-      expect(code.length, 18);
+      final code = await service.generateCode(testUserId);
+      expect(code, isNotEmpty);
 
       // 2. 코드 검증
       await expectLater(service.verifyCode(code), completes);
 
-      // 3. userId 해시값 추출
-      final extractedHash = await service.extractUserId(code);
-      expect(extractedHash, isNotEmpty);
+      // 3. userId 추출
+      final extractedUserId = await service.extractUserId(code);
+      expect(extractedUserId, testUserId);
     });
   });
 }


### PR DESCRIPTION
## 요약

기존의 challenger_code_service에서 코드를 생성하는 방식은 해싱을 사용하는 중이었습니다. (Cursor를 너무 믿은 탓이네요..)
암호화되었던 값을 다시 원복시키기위해, 해싱이 아닌 대칭키 암호화처리를 하도록 수정합니다.

사실 원흉은 잘 못 짜여진 테스트 코드 때문이었습니다. (cursor한테 너무 일을 위임하면 안되나봐요)
테스트코드 중 extractUserId 메서드에 대한 테스트를 진행할때, 반환 문자열과 기존 userId가 동일한지 체크를 하지 않고, 다른걸 검증하고 있더라구요. (아마 원본 코드가 해싱처리이기 때문에 이렇게 테스트 코드를 짠것 같네요)

![image](https://github.com/user-attachments/assets/c5e4f2b5-6c50-40b1-ae55-99f8af123f1f)
그래서 위와 같이 extractedString === userId 여부를 체크하는 테스트코드로 변경하고, 작업을 진행하였습니다.


그 밖에 자세한 변경 사항은 토끼 선생이 잘 해주길 것 같습니다.

## 작업 내용

- [fix: extractUserId가 의도대로 동작하지 않는 문제 수정](https://github.com/buku-buku/notiyou/pull/54/commits/42fea3d2e387727eeafc286118bc26b8362dfccb)
- [test: 코드 생성 관련 테스트 코드 수정](https://github.com/buku-buku/notiyou/pull/54/commits/475fd3f3009e3ea591b061dda0a7873715eda920)
- [chore: ios/Podfile.lock 업데이트](https://github.com/buku-buku/notiyou/pull/54/commits/e555a86a7844177a9f84cfb5bbc398f1019af006)

## 기타 사항

- 암호화를 위한 키를 환경변수에 추가하였습니다.


## 체크리스트

- @datalater , @42KIM  해당 작업으로 인해 새로운 환경변수 값들이 추가되었습니다. [노션](https://www.notion.so/0378356b4f5647619e0598575c56d7e0?pvs=4#74b2f7863af6459f8dd1ee3bfb37aade) 문서에 업데이트해두었으니 참고하여 반영해주세용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - 사용자 코드를 보다 안전하게 생성 및 검증할 수 있도록 AES 암호화 기반 접근 방식을 도입했습니다.
  - 환경 변수를 테스트할 수 있는 새로운 메서드를 추가했습니다.
- **Chores**
  - 보안 기능 강화를 위해 최신 암호화 라이브러리와 메타데이터 라이브러리를 프로젝트에 추가했습니다.
- **Tests**
  - 새로운 암호화 방식에 맞춰 테스트 케이스를 업데이트하여 기능 안정성을 개선했습니다.
  - 테스트에서 사용자 ID를 일관되게 사용하도록 변경했습니다.
- **Bug Fixes**
  - 예외 처리 시 더 많은 정보를 제공하도록 예외 클래스를 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->