### PR TITLE
[NY-102] mission_time_table 개편(1) - missionNumber 없애기 대작전

### DIFF
--- a/lib/models/mission.dart
+++ b/lib/models/mission.dart
@@ -19,7 +19,6 @@ class Mission {
 
   Mission copyWith({
     int? id,
-    int? missionNumber,
     TimeOfDay? time,
     bool? isCompleted,
     DateTime? completedAt,

--- a/lib/models/mission.dart
+++ b/lib/models/mission.dart
@@ -3,8 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:notiyou/utils/time_utils.dart';
 
 class Mission {
-  final String id;
-  final int missionNumber;
+  final int id;
   final TimeOfDay time;
   final bool isCompleted;
   final DateTime? completedAt;
@@ -12,7 +11,6 @@ class Mission {
 
   Mission({
     required this.id,
-    required this.missionNumber,
     required this.time,
     required this.isCompleted,
     this.completedAt,
@@ -20,7 +18,7 @@ class Mission {
   });
 
   Mission copyWith({
-    String? id,
+    int? id,
     int? missionNumber,
     TimeOfDay? time,
     bool? isCompleted,
@@ -30,7 +28,6 @@ class Mission {
     final newIsCompleted = isCompleted ?? this.isCompleted;
     return Mission(
       id: id ?? this.id,
-      missionNumber: missionNumber ?? this.missionNumber,
       time: time ?? this.time,
       isCompleted: newIsCompleted,
       completedAt: newIsCompleted ? (completedAt ?? this.completedAt) : null,
@@ -40,7 +37,6 @@ class Mission {
 
   Map<String, dynamic> toJson() => {
         'id': id,
-        'missionNumber': missionNumber,
         'time': TimeUtils.stringifyTime(time),
         'isCompleted': isCompleted,
         'completedAt': completedAt?.toIso8601String(),
@@ -49,7 +45,6 @@ class Mission {
 
   factory Mission.fromJson(Map<String, dynamic> json) => Mission(
         id: json['id'],
-        missionNumber: json['missionNumber'],
         time: TimeUtils.parseTime(json['time']),
         isCompleted: json['isCompleted'],
         completedAt: json['completedAt'] != null
@@ -60,8 +55,7 @@ class Mission {
 
   factory Mission.fromMissionHistoryEntity(Map<String, dynamic> json) =>
       Mission(
-        id: json['id'].toString(),
-        missionNumber: json['challenger_mission_time']['mission_number'],
+        id: json['id'],
         time: TimeUtils.parseTime(json['mission_at']),
         isCompleted: json['done_at'] != null,
         completedAt:

--- a/lib/models/mission_time_model.dart
+++ b/lib/models/mission_time_model.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:notiyou/utils/time_utils.dart';
+
+class MissionTime {
+  final int id;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final String challengerId;
+  final TimeOfDay missionAt;
+  final String? supporterId;
+
+  MissionTime({
+    required this.id,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.challengerId,
+    required this.missionAt,
+    required this.supporterId,
+  });
+
+  factory MissionTime.fromJson({
+    required int id,
+    required String createdAt,
+    required String updatedAt,
+    required String challengerId,
+    required String missionAt,
+    required String? supporterId,
+  }) =>
+      MissionTime(
+        id: id,
+        createdAt: TimeUtils.parseDate(createdAt),
+        updatedAt: TimeUtils.parseDate(updatedAt),
+        challengerId: challengerId,
+        missionAt: TimeUtils.parseTime(missionAt),
+        supporterId: supporterId,
+      );
+
+  MissionTime copyWith({
+    int? id,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? challengerId,
+    TimeOfDay? missionAt,
+    String? supporterId,
+  }) {
+    return MissionTime(
+      id: id ?? this.id,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      challengerId: challengerId ?? this.challengerId,
+      missionAt: missionAt ?? this.missionAt,
+      supporterId: supporterId ?? this.supporterId,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'created_at': TimeUtils.stringifyDate(createdAt),
+        'updated_at': TimeUtils.stringifyDate(updatedAt),
+        'challenger_id': challengerId,
+        'mission_at': TimeUtils.stringifyTime(missionAt),
+        'supporter_id': supporterId,
+      };
+}

--- a/lib/models/mission_time_model.dart
+++ b/lib/models/mission_time_model.dart
@@ -15,7 +15,7 @@ class MissionTime {
     required this.updatedAt,
     required this.challengerId,
     required this.missionAt,
-    required this.supporterId,
+    this.supporterId,
   });
 
   factory MissionTime.fromJson({

--- a/lib/repositories/mission_grace_period_repository_remote.dart
+++ b/lib/repositories/mission_grace_period_repository_remote.dart
@@ -1,4 +1,5 @@
 import 'package:notiyou/repositories/mission_grace_period_repository_interface.dart';
+import 'package:notiyou/repositories/supabase_table_names_constants.dart';
 import 'package:notiyou/services/supabase_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -23,7 +24,7 @@ class MissionGracePeriodRepositoryRemote
     }
 
     final gracePeriod = await supabaseClient
-        .from('challenger_grace_period')
+        .from(SupabaseTableNames.challengerGracePeriod)
         .select('grace_period')
         .eq('challenger_id', userId);
 
@@ -38,13 +39,13 @@ class MissionGracePeriodRepositoryRemote
     }
 
     final hasGracePeriod = await supabaseClient
-        .from('challenger_grace_period')
+        .from(SupabaseTableNames.challengerGracePeriod)
         .select('id')
         .eq('challenger_id', userId);
 
     if (hasGracePeriod.isNotEmpty) {
       await supabaseClient
-          .from('challenger_grace_period')
+          .from(SupabaseTableNames.challengerGracePeriod)
           .update({'grace_period': gracePeriod}).eq('challenger_id', userId);
     } else {
       await supabaseClient

--- a/lib/repositories/mission_history_repository_interface.dart
+++ b/lib/repositories/mission_history_repository_interface.dart
@@ -4,14 +4,12 @@ import 'package:notiyou/models/mission.dart';
 abstract interface class MissionHistoryRepository {
   Future<void> init();
 
-  // TODO: missionId로 생성하도록 변경
-  Future<void> createTodayMission(int missionNumber);
+  Future<void> createTodayMission(int missionId);
 
-  Future<bool> hasTodayMission(int missionNumber);
+  Future<bool> hasTodayMission(int missionId);
 
-// TODO: missionNumber가 아닌 id로 업데이트
   Future<void> updateTodayMissionTime(
-    int missionNumber,
+    int missionId,
     TimeOfDay time,
   );
 
@@ -20,10 +18,9 @@ abstract interface class MissionHistoryRepository {
   // TODO: findMissions에 날짜 범위로 조회 기능 추가
   Future<List<Mission>> findMissions(DateTime date);
 
-  Future<Mission?> findMissionById(String id);
+  Future<Mission?> findMissionById(int missionId);
 
-  // TODO: removeMissionById를 제공하고 해당 메서드 삭제
-  Future<void> removeTodayMission(int missionNumber);
+  Future<void> removeTodayMission(int missionId);
 
   Future<List<Mission>> findAllMissions();
 }

--- a/lib/repositories/mission_history_repository_local.dart
+++ b/lib/repositories/mission_history_repository_local.dart
@@ -56,19 +56,19 @@ class MissionHistoryRepositoryLocal implements MissionHistoryRepository {
   }
 
   @override
-  Future<void> createTodayMission(int missionNumber) async {
+  Future<void> createTodayMission(int missionId) async {
     throw UnimplementedError('createTodayMission is not implemented');
   }
 
   @override
-  Future<bool> hasTodayMission(int missionNumber) async {
+  Future<bool> hasTodayMission(int missionId) async {
     final missions = await findMissions(DateTime.now());
-    return missions.any((e) => e.missionNumber == missionNumber);
+    return missions.any((e) => e.id == missionId);
   }
 
   @override
   Future<void> updateTodayMissionTime(
-    int missionNumber,
+    int missionId,
     TimeOfDay time,
   ) async {
     throw UnimplementedError('updateTodayMissionTime is not implemented');
@@ -93,7 +93,7 @@ class MissionHistoryRepositoryLocal implements MissionHistoryRepository {
 
   /// ! 현재는 오늘의 미션에 대한 찾기만 지원함.
   @override
-  Future<Mission?> findMissionById(String id) async {
+  Future<Mission?> findMissionById(int id) async {
     final missions = await findMissions(DateTime.now());
     try {
       return missions.firstWhere((m) => m.id == id);
@@ -102,23 +102,9 @@ class MissionHistoryRepositoryLocal implements MissionHistoryRepository {
     }
   }
 
-  Future<Mission?> _findMissionByMissionNumber(
-      DateTime date, int missionNumber) async {
-    final missions = await findMissions(date);
-    try {
-      return missions.firstWhere((m) => m.missionNumber == missionNumber);
-    } catch (e) {
-      return null;
-    }
-  }
-
   @override
-  Future<void> removeTodayMission(int missionNumber) async {
-    final today = DateTime.now();
-    final mission = await _findMissionByMissionNumber(today, missionNumber);
-    if (mission != null) {
-      await _removeMissionById(today, mission.id);
-    }
+  Future<void> removeTodayMission(int missionId) async {
+    throw UnimplementedError('removeTodayMission is not implemented');
   }
 
   Future<void> _removeMissionById(DateTime date, String id) async {

--- a/lib/repositories/mission_history_repository_local.dart
+++ b/lib/repositories/mission_history_repository_local.dart
@@ -44,17 +44,6 @@ class MissionHistoryRepositoryLocal implements MissionHistoryRepository {
     return '${_missionStoreKey}_${TimeUtils.stringifyYearMonthDay(date)}';
   }
 
-  /// 미션 데이터 저장
-  /// 이후 해당 메서드는 서버에서 데이터를 받아오는 것을 대비한 캐싱 목적으로만 존재합니다.
-  Future<void> _setMissions(DateTime date, List<Mission> missions) async {
-    final key = _getKeyForDate(date);
-    if (_prefs == null) await init();
-
-    final missionJsonList =
-        missions.map((m) => jsonEncode(m.toJson())).toList();
-    await _prefs!.setStringList(key, missionJsonList);
-  }
-
   @override
   Future<void> createTodayMission(int missionId) async {
     throw UnimplementedError('createTodayMission is not implemented');
@@ -105,12 +94,6 @@ class MissionHistoryRepositoryLocal implements MissionHistoryRepository {
   @override
   Future<void> removeTodayMission(int missionId) async {
     throw UnimplementedError('removeTodayMission is not implemented');
-  }
-
-  Future<void> _removeMissionById(DateTime date, String id) async {
-    final missions = await findMissions(date);
-    final updatedMissions = missions.where((m) => m.id != id).toList();
-    await _setMissions(date, updatedMissions);
   }
 
   @override

--- a/lib/repositories/mission_time_repository_interface.dart
+++ b/lib/repositories/mission_time_repository_interface.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:notiyou/models/mission_time_model.dart';
 
 abstract interface class MissionTimeRepository {
   Future<void> init();
-  Future<TimeOfDay?> getMissionTime(int missionNumber);
-  Future<void> setMissionTime(int missionNumber, TimeOfDay time);
-  Future<void> clearMissionTime(int missionNumber);
+  Future<List<MissionTime?>> getMissionTimes();
+  Future<MissionTime?> getMissionTime(int missionId);
+  Future<MissionTime> setMissionTime(TimeOfDay time);
+  Future<void> updateMissionTime(int missionId, TimeOfDay time);
+  Future<void> removeMissionTime(int missionId);
 }

--- a/lib/repositories/mission_time_repository_interface.dart
+++ b/lib/repositories/mission_time_repository_interface.dart
@@ -5,7 +5,7 @@ abstract interface class MissionTimeRepository {
   Future<void> init();
   Future<List<MissionTime?>> getMissionTimes();
   Future<MissionTime?> getMissionTime(int missionId);
-  Future<MissionTime> setMissionTime(TimeOfDay time);
+  Future<MissionTime> createMissionTime(TimeOfDay time);
   Future<void> updateMissionTime(int missionId, TimeOfDay time);
   Future<void> removeMissionTime(int missionId);
   Future getMissionByUserId(String userId);

--- a/lib/repositories/mission_time_repository_local.dart
+++ b/lib/repositories/mission_time_repository_local.dart
@@ -32,7 +32,7 @@ class MissionTimeRepositoryLocal implements MissionTimeRepository {
   }
 
   @override
-  Future<List<MissionTime>> getMissionTimes() async {
+  Future<List<MissionTime?>> getMissionTimes() async {
     throw UnimplementedError();
   }
 
@@ -43,7 +43,7 @@ class MissionTimeRepositoryLocal implements MissionTimeRepository {
 
   // 미션 시간 설정
   @override
-  Future<MissionTime> setMissionTime(TimeOfDay time) async {
+  Future<MissionTime> createMissionTime(TimeOfDay time) async {
     throw UnimplementedError();
   }
 

--- a/lib/repositories/mission_time_repository_local.dart
+++ b/lib/repositories/mission_time_repository_local.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:notiyou/models/mission_time_model.dart';
 import 'package:notiyou/repositories/mission_time_repository_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:notiyou/utils/time_utils.dart';
 
 /// 미션 시간 데이터를 관리하는 저장소입니다.
 ///
@@ -31,33 +31,32 @@ class MissionTimeRepositoryLocal implements MissionTimeRepository {
     _prefs ??= await SharedPreferences.getInstance();
   }
 
-  String _getMissionKey(int missionNumber) => 'mission$missionNumber';
+  String _getMissionKey(String missionId) => 'mission$missionId';
 
-  // 미션 시간 조회
   @override
-  Future<TimeOfDay?> getMissionTime(int missionNumber) async {
-    await init();
-    final key = _getMissionKey(missionNumber);
-    final timeStr = _prefs!.getString(key);
+  Future<List<MissionTime>> getMissionTimes() async {
+    throw UnimplementedError();
+  }
 
-    if (timeStr == null) return null;
-
-    return TimeUtils.parseTime(timeStr);
+  @override
+  Future<MissionTime?> getMissionTime(int missionId) async {
+    throw UnimplementedError();
   }
 
   // 미션 시간 설정
   @override
-  Future<void> setMissionTime(int missionNumber, TimeOfDay time) async {
-    await init();
-    final key = _getMissionKey(missionNumber);
-    await _prefs!.setString(key, TimeUtils.stringifyTime(time));
+  Future<MissionTime> setMissionTime(TimeOfDay time) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> updateMissionTime(int missionId, TimeOfDay time) {
+    throw UnimplementedError();
   }
 
   // 미션 시간 초기화
   @override
-  Future<void> clearMissionTime(int missionNumber) async {
-    await init();
-    final key = _getMissionKey(missionNumber);
-    await _prefs!.remove(key);
+  Future<void> removeMissionTime(int missionId) async {
+    throw UnimplementedError();
   }
 }

--- a/lib/repositories/mission_time_repository_local.dart
+++ b/lib/repositories/mission_time_repository_local.dart
@@ -31,8 +31,6 @@ class MissionTimeRepositoryLocal implements MissionTimeRepository {
     _prefs ??= await SharedPreferences.getInstance();
   }
 
-  String _getMissionKey(String missionId) => 'mission$missionId';
-
   @override
   Future<List<MissionTime>> getMissionTimes() async {
     throw UnimplementedError();

--- a/lib/repositories/mission_time_repository_local.dart
+++ b/lib/repositories/mission_time_repository_local.dart
@@ -48,7 +48,7 @@ class MissionTimeRepositoryLocal implements MissionTimeRepository {
   }
 
   @override
-  Future<void> updateMissionTime(int missionId, TimeOfDay time) {
+  Future<void> updateMissionTime(int missionId, TimeOfDay time) async {
     throw UnimplementedError();
   }
 

--- a/lib/repositories/mission_time_repository_remote.dart
+++ b/lib/repositories/mission_time_repository_remote.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:notiyou/repositories/mission_time_repository_interface.dart';
+import 'package:notiyou/repositories/supabase_table_names_constants.dart';
 import 'package:notiyou/services/supabase_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:notiyou/utils/time_utils.dart';
@@ -35,7 +36,7 @@ class MissionTimeRepositoryRemote implements MissionTimeRepository {
     }
 
     final mission = await supabaseClient
-        .from('challenger_mission_time')
+        .from(SupabaseTableNames.challengerMissionTime)
         .select('mission_at')
         .eq('challenger_id', userId)
         .eq('mission_number', missionNumber);
@@ -53,19 +54,21 @@ class MissionTimeRepositoryRemote implements MissionTimeRepository {
       throw const AuthException('User not found');
     }
     final hasMission = await supabaseClient
-        .from('challenger_mission_time')
+        .from(SupabaseTableNames.challengerMissionTime)
         .select('id')
         .eq('challenger_id', userId)
         .eq('mission_number', missionNumber);
 
     if (hasMission.isNotEmpty) {
       await supabaseClient
-          .from('challenger_mission_time')
+          .from(SupabaseTableNames.challengerMissionTime)
           .update({'mission_at': TimeUtils.stringifyTime(time)})
           .eq('challenger_id', userId)
           .eq('mission_number', missionNumber);
     } else {
-      await supabaseClient.from('challenger_mission_time').insert({
+      await supabaseClient
+          .from(SupabaseTableNames.challengerMissionTime)
+          .insert({
         'challenger_id': userId,
         'mission_number': missionNumber,
         'mission_at': TimeUtils.stringifyTime(time),
@@ -81,7 +84,7 @@ class MissionTimeRepositoryRemote implements MissionTimeRepository {
       throw const AuthException('User not found');
     }
     await supabaseClient
-        .from('challenger_mission_time')
+        .from(SupabaseTableNames.challengerMissionTime)
         .delete()
         .eq('challenger_id', userId)
         .eq('mission_number', missionNumber);

--- a/lib/repositories/mission_time_repository_remote.dart
+++ b/lib/repositories/mission_time_repository_remote.dart
@@ -100,7 +100,7 @@ class MissionTimeRepositoryRemote implements MissionTimeRepository {
 
   // 미션 시간 설정
   @override
-  Future<MissionTime> setMissionTime(TimeOfDay time) async {
+  Future<MissionTime> createMissionTime(TimeOfDay time) async {
     final userId = supabaseClient.auth.currentUser?.id;
     if (userId == null) {
       throw const AuthException('User not found');
@@ -132,8 +132,11 @@ class MissionTimeRepositoryRemote implements MissionTimeRepository {
     if (userId == null) {
       throw const AuthException('User not found');
     }
-    await supabaseClient.from(SupabaseTableNames.missionTime).update(
-        {'mission_at': TimeUtils.stringifyTime(time)}).eq('id', missionId);
+    await supabaseClient
+        .from(SupabaseTableNames.missionTime)
+        .update({'mission_at': TimeUtils.stringifyTime(time)})
+        .eq('id', missionId)
+        .eq('challenger_id', userId);
   }
 
   // 미션 시간 초기화

--- a/lib/repositories/supabase_table_names_constants.dart
+++ b/lib/repositories/supabase_table_names_constants.dart
@@ -1,0 +1,7 @@
+// abstract class를 사용하면 상속받은 클래스에서 생성자를 호출할 수 없다.
+final class SupabaseTableNames {
+  static const challengerGracePeriod = 'challenger_grace_period';
+  static const missionHistory = 'mission_history';
+  static const missionMessages = 'mission_messages';
+  static const challengerMissionTime = 'challenger_mission_time';
+}

--- a/lib/repositories/supabase_table_names_constants.dart
+++ b/lib/repositories/supabase_table_names_constants.dart
@@ -3,5 +3,5 @@ final class SupabaseTableNames {
   static const challengerGracePeriod = 'challenger_grace_period';
   static const missionHistory = 'mission_history';
   static const missionMessages = 'mission_messages';
-  static const challengerMissionTime = 'challenger_mission_time';
+  static const missionTime = 'mission_time';
 }

--- a/lib/repositories/supporter_repository.dart
+++ b/lib/repositories/supporter_repository.dart
@@ -1,5 +1,6 @@
 import 'package:notiyou/services/supabase_service.dart';
 
+// TODO: 사용 여부 확인
 class SupporterRepository {
   static Future<Map<String, dynamic>?> getSupporter(String userId) async {
     try {

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:notiyou/models/mission_time_model.dart';
 import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
@@ -22,9 +23,16 @@ class ChallengerConfigPage extends StatefulWidget {
   State<ChallengerConfigPage> createState() => _ChallengerConfigPageState();
 }
 
+class _MissionTimeConfig {
+  int? missionId;
+  TimeOfDay? missionTime;
+
+  _MissionTimeConfig({required this.missionId, required this.missionTime});
+}
+
 class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
-  TimeOfDay? _mission1Time;
-  TimeOfDay? _mission2Time;
+  _MissionTimeConfig? _mission1TimeConfig;
+  _MissionTimeConfig? _mission2TimeConfig;
   int _selectedGracePeriod = 0;
   bool _isSubmitLoading = false;
 
@@ -36,13 +44,21 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
   }
 
   Future<void> _loadSavedTimes() async {
-    final results = await Future.wait([
-      MissionConfigService.getMissionTime(1),
-      MissionConfigService.getMissionTime(2),
-    ]);
+    final results = await MissionConfigService.getMissionTimes();
     setState(() {
-      _mission1Time = results[0];
-      _mission2Time = results[1];
+      for (int i = 0; i < results.length; i++) {
+        if (i == 0) {
+          _mission1TimeConfig = _MissionTimeConfig(
+            missionId: results[i]!.id,
+            missionTime: results[i]!.missionAt,
+          );
+        } else if (i == 1) {
+          _mission2TimeConfig = _MissionTimeConfig(
+            missionId: results[i]!.id,
+            missionTime: results[i]!.missionAt,
+          );
+        }
+      }
     });
   }
 
@@ -54,36 +70,57 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
   }
 
   Future<void> _saveTimes() async {
-    final bool hasTimeChanged =
-        _mission1Time != await MissionConfigService.getMissionTime(1) ||
-            _mission2Time != await MissionConfigService.getMissionTime(2) ||
-            _selectedGracePeriod != await MissionConfigService.getGracePeriod();
+    final mission1TimeConfig = _mission1TimeConfig;
+    final mission2TimeConfig = _mission2TimeConfig;
 
-    if (hasTimeChanged == false) {
-      return;
+    if (mission1TimeConfig?.missionTime != null) {
+      await MissionConfigService.saveMissionTime(
+          mission1TimeConfig!.missionTime!, mission1TimeConfig.missionId);
+    } else if (mission1TimeConfig != null &&
+        mission1TimeConfig.missionId != null) {
+      await MissionConfigService.clearMissionTime(
+        missionId: mission1TimeConfig.missionId!,
+        missionAt: mission1TimeConfig.missionTime!.hour * 60 +
+            mission1TimeConfig.missionTime!.minute,
+      );
+    }
+    if (mission2TimeConfig?.missionTime != null) {
+      await MissionConfigService.saveMissionTime(
+          mission2TimeConfig!.missionTime!, mission2TimeConfig.missionId);
+    } else if (mission2TimeConfig != null &&
+        mission2TimeConfig.missionId != null) {
+      await MissionConfigService.clearMissionTime(
+        missionId: mission2TimeConfig.missionId!,
+        missionAt: mission2TimeConfig.missionTime!.hour * 60 +
+            mission2TimeConfig.missionTime!.minute,
+      );
     }
 
-    await MissionConfigService.saveMissionTime(1, _mission1Time);
-    await MissionConfigService.saveMissionTime(2, _mission2Time);
     await MissionConfigService.saveGracePeriod(_selectedGracePeriod);
   }
 
   Future<void> _selectTime(BuildContext context, bool isFirstMission) async {
+    print('selectTime: $isFirstMission');
     final initialTime = isFirstMission
-        ? _mission1Time ?? TimeOfDay.now()
-        : _mission2Time ?? TimeOfDay.now();
+        ? _mission1TimeConfig?.missionTime ?? TimeOfDay.now()
+        : _mission2TimeConfig?.missionTime ?? TimeOfDay.now();
 
     final TimeOfDay? picked = await showTimePicker(
       context: context,
       initialTime: initialTime,
     );
 
+    print('picked: $picked');
+
     if (picked != null) {
       setState(() {
         if (isFirstMission) {
-          _mission1Time = picked;
+          _mission1TimeConfig = _MissionTimeConfig(
+              missionId: _mission1TimeConfig?.missionId, missionTime: picked);
+          print('mission1Time: $_mission1TimeConfig');
         } else {
-          _mission2Time = picked;
+          _mission2TimeConfig = _MissionTimeConfig(
+              missionId: _mission2TimeConfig?.missionId, missionTime: picked);
         }
       });
     }
@@ -92,9 +129,9 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
   void _resetTime(bool isFirstMission) {
     setState(() {
       if (isFirstMission) {
-        _mission1Time = null;
+        _mission1TimeConfig = null;
       } else {
-        _mission2Time = null;
+        _mission2TimeConfig = null;
       }
     });
   }
@@ -115,7 +152,7 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
   }
 
   bool _isSubmittable() {
-    return _mission1Time != null;
+    return _mission1TimeConfig != null;
   }
 
   Future<void> _handleSubmit() async {
@@ -205,11 +242,12 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
                   TextButton(
                     onPressed: () => _selectTime(context, true),
                     child: Text(
-                      _mission1Time?.format(context) ?? '시간 선택',
+                      _mission1TimeConfig?.missionTime?.format(context) ??
+                          '시간 선택',
                       style: const TextStyle(fontSize: 16),
                     ),
                   ),
-                  if (_mission1Time != null)
+                  if (_mission1TimeConfig != null)
                     IconButton(
                       icon: const Icon(Icons.clear),
                       onPressed: () => _resetTime(true),
@@ -225,11 +263,12 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
                   TextButton(
                     onPressed: () => _selectTime(context, false),
                     child: Text(
-                      _mission2Time?.format(context) ?? '시간 선택',
+                      _mission2TimeConfig?.missionTime?.format(context) ??
+                          '시간 선택',
                       style: const TextStyle(fontSize: 16),
                     ),
                   ),
-                  if (_mission2Time != null)
+                  if (_mission2TimeConfig != null)
                     IconButton(
                       icon: const Icon(Icons.clear),
                       onPressed: () => _resetTime(false),

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -43,22 +43,33 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
   }
 
   Future<void> _loadSavedTimes() async {
-    final results = await MissionConfigService.getMissionTimes();
-    setState(() {
-      for (int i = 0; i < results.length; i++) {
-        if (i == 0) {
-          _mission1TimeConfig = _MissionTimeConfig(
-            missionId: results[i]!.id,
-            missionTime: results[i]!.missionAt,
-          );
-        } else if (i == 1) {
-          _mission2TimeConfig = _MissionTimeConfig(
-            missionId: results[i]!.id,
-            missionTime: results[i]!.missionAt,
-          );
+    try {
+      final results = await MissionConfigService.getMissionTimes();
+      setState(() {
+        for (int i = 0; i < results.length; i++) {
+          if (i == 0) {
+            _mission1TimeConfig = _MissionTimeConfig(
+              missionId: results[i]!.id,
+              missionTime: results[i]!.missionAt,
+            );
+          } else if (i == 1) {
+            _mission2TimeConfig = _MissionTimeConfig(
+              missionId: results[i]!.id,
+              missionTime: results[i]!.missionAt,
+            );
+          }
         }
+      });
+    } catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content:
+                Text('미션 시간을 불러오는 중 오류가 발생했습니다. Error: ${error.toString()}'),
+          ),
+        );
       }
-    });
+    }
   }
 
   Future<void> _loadSavedGracePeriod() async {
@@ -147,16 +158,26 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
   }
 
   Future<void> _handleSubmit() async {
-    if (_isSubmittable() == false) return;
-    setState(() => _isSubmitLoading = true);
-    await _saveTimes();
-    if (widget.isFirstTime) {
-      AuthService.setRole(UserRole.challenger);
+    try {
+      if (_isSubmittable() == false) return;
+      setState(() => _isSubmitLoading = true);
+      await _saveTimes();
+      if (widget.isFirstTime) {
+        AuthService.setRole(UserRole.challenger);
+      }
+      if (mounted) {
+        context.go(HomePage.routeName);
+      }
+      setState(() => _isSubmitLoading = false);
+    } catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('설정을 저장하는 중 오류가 발생했습니다. Error: ${error.toString()}'),
+          ),
+        );
+      }
     }
-    if (mounted) {
-      context.go(HomePage.routeName);
-    }
-    setState(() => _isSubmitLoading = false);
   }
 
   Future<void> _showGracePeriodExplanation() async {

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -79,8 +79,6 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
         mission1TimeConfig.missionId != null) {
       await MissionConfigService.clearMissionTime(
         missionId: mission1TimeConfig.missionId!,
-        missionAt: mission1TimeConfig.missionTime!.hour * 60 +
-            mission1TimeConfig.missionTime!.minute,
       );
     }
     if (mission2TimeConfig?.missionTime != null) {
@@ -90,8 +88,6 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
         mission2TimeConfig.missionId != null) {
       await MissionConfigService.clearMissionTime(
         missionId: mission2TimeConfig.missionId!,
-        missionAt: mission2TimeConfig.missionTime!.hour * 60 +
-            mission2TimeConfig.missionTime!.minute,
       );
     }
 

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:notiyou/models/mission_time_model.dart';
 import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
@@ -100,7 +99,6 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
   }
 
   Future<void> _selectTime(BuildContext context, bool isFirstMission) async {
-    print('selectTime: $isFirstMission');
     final initialTime = isFirstMission
         ? _mission1TimeConfig?.missionTime ?? TimeOfDay.now()
         : _mission2TimeConfig?.missionTime ?? TimeOfDay.now();
@@ -110,14 +108,11 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
       initialTime: initialTime,
     );
 
-    print('picked: $picked');
-
     if (picked != null) {
       setState(() {
         if (isFirstMission) {
           _mission1TimeConfig = _MissionTimeConfig(
               missionId: _mission1TimeConfig?.missionId, missionTime: picked);
-          print('mission1Time: $_mission1TimeConfig');
         } else {
           _mission2TimeConfig = _MissionTimeConfig(
               missionId: _mission2TimeConfig?.missionId, missionTime: picked);

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -83,7 +83,7 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
-  Future<void> _toggleMissionComplete(String missionId) async {
+  Future<void> _toggleMissionComplete(int missionId) async {
     final newState =
         await MissionHistoryService.toggleMissionComplete(missionId);
     setState(() {
@@ -91,7 +91,6 @@ class _HomePageState extends State<HomePage> {
         if (mission.id == missionId) {
           return Mission(
             id: mission.id,
-            missionNumber: mission.missionNumber,
             time: mission.time,
             isCompleted: newState,
             completedAt: newState ? DateTime.now() : null,

--- a/lib/services/auth/kakao_auth_service.dart
+++ b/lib/services/auth/kakao_auth_service.dart
@@ -23,7 +23,7 @@ class KakaoAuthService {
     try {
       return await _kakaoUserApi.loginWithKakaoAccount();
     } catch (error) {
-      return null;
+      rethrow;
     }
   }
 

--- a/lib/services/mission_alarm_service.dart
+++ b/lib/services/mission_alarm_service.dart
@@ -36,19 +36,19 @@ class MissionAlarmService {
     if (!await AuthService.isLoggedIn()) {
       return;
     }
-    final firstMissionTime = await _missionTimeRepository.getMissionTime(1);
-    final secondMissionTime = await _missionTimeRepository.getMissionTime(2);
+    final missionTimes = await _missionTimeRepository.getMissionTimes();
 
-    if (firstMissionTime != null) {
-      await scheduleAlarm(1, firstMissionTime);
-    }
-    if (secondMissionTime != null) {
-      await scheduleAlarm(2, secondMissionTime);
+    for (var missionTime in missionTimes) {
+      if (missionTime == null) {
+        continue;
+      }
+
+      scheduleAlarm(missionTime.id, missionTime.missionAt);
     }
   }
 
   static Future<void> scheduleAlarm(
-      int missionNumber, TimeOfDay missionTime) async {
+      int missionId, TimeOfDay missionTime) async {
     final now = DateTime.now();
     var scheduledTime = DateTime(
       now.year,
@@ -63,7 +63,7 @@ class MissionAlarmService {
     }
 
     await LocalNotificationService.scheduleNotification(
-      id: missionNumber,
+      id: missionId,
       title: '미션 알림',
       body: '미션 시간입니다!',
       scheduledTime: scheduledTime,
@@ -71,19 +71,19 @@ class MissionAlarmService {
     );
   }
 
-  static Future<void> cancelAlarm(int missionNumber) async {
-    await LocalNotificationService.cancelNotification(missionNumber);
+  static Future<void> cancelAlarm(int missionId) async {
+    await LocalNotificationService.cancelNotification(missionId);
   }
 
   static Future<void> cancelAllAlarms() async {
     await LocalNotificationService.cancelAllNotifications();
   }
 
-  static Future<void> updateAlarm(int missionNumber, TimeOfDay? time) async {
-    await cancelAlarm(missionNumber);
+  static Future<void> updateAlarm(int missionId, TimeOfDay? time) async {
+    await cancelAlarm(missionId);
 
     if (time != null) {
-      await scheduleAlarm(missionNumber, time);
+      await scheduleAlarm(missionId, time);
     }
   }
 }

--- a/lib/services/mission_config_service.dart
+++ b/lib/services/mission_config_service.dart
@@ -31,7 +31,7 @@ class MissionConfigService {
   ) async {
     var missionIdToSave = missionId;
     if (missionId == null) {
-      final mission = await _missionTimeRepository.setMissionTime(time);
+      final mission = await _missionTimeRepository.createMissionTime(time);
       missionIdToSave = mission.id;
     } else {
       await _missionTimeRepository.updateMissionTime(missionId, time);
@@ -53,7 +53,6 @@ class MissionConfigService {
 
   static Future<void> clearMissionTime({
     required int missionId,
-    required int missionAt,
   }) async {
     await _missionTimeRepository.removeMissionTime(missionId);
     await _missionHistoryRepository.removeTodayMission(missionId);

--- a/lib/services/mission_config_service.dart
+++ b/lib/services/mission_config_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:notiyou/models/mission_time_model.dart';
 import 'package:notiyou/repositories/mission_grace_period_repository_remote.dart';
 import 'package:notiyou/repositories/mission_grace_period_repository_interface.dart';
 import 'package:notiyou/repositories/mission_grace_period_repository_local.dart';
@@ -24,31 +25,49 @@ class MissionConfigService {
     await _missionHistoryRepository.init();
   }
 
-  // 미션 시간 저장
   static Future<void> saveMissionTime(
-    int missionNumber,
-    TimeOfDay? time,
+    TimeOfDay time,
+    int? missionId,
   ) async {
-    if (time != null) {
-      await _missionTimeRepository.setMissionTime(missionNumber, time);
-      if (await _missionHistoryRepository.hasTodayMission(missionNumber)) {
-        await _missionHistoryRepository.updateTodayMissionTime(
-            missionNumber, time);
-      } else {
-        await _missionHistoryRepository.createTodayMission(missionNumber);
-      }
+    var missionIdToSave = missionId;
+    if (missionId == null) {
+      final mission = await _missionTimeRepository.setMissionTime(time);
+      missionIdToSave = mission.id;
     } else {
-      await _missionTimeRepository.clearMissionTime(missionNumber);
-      // 미션 시간 삭제시 오늘의 미션 삭제
-      await _missionHistoryRepository.removeTodayMission(missionNumber);
+      await _missionTimeRepository.updateMissionTime(missionId, time);
     }
 
-    await MissionAlarmService.updateAlarm(missionNumber, time);
+    if (missionIdToSave == null) {
+      throw Exception('missionIdToSave is null');
+    }
+
+    if (await _missionHistoryRepository.hasTodayMission(missionIdToSave)) {
+      await _missionHistoryRepository.updateTodayMissionTime(
+          missionIdToSave, time);
+    } else {
+      await _missionHistoryRepository.createTodayMission(missionIdToSave);
+    }
+
+    await MissionAlarmService.updateAlarm(missionIdToSave, time);
   }
 
-  // 미션 시간 불러오기
-  static Future<TimeOfDay?> getMissionTime(int missionNumber) async {
-    final time = await _missionTimeRepository.getMissionTime(missionNumber);
+  static Future<void> clearMissionTime({
+    required int missionId,
+    required int missionAt,
+  }) async {
+    await _missionTimeRepository.removeMissionTime(missionId);
+    await _missionHistoryRepository.removeTodayMission(missionId);
+    await MissionAlarmService.cancelAlarm(missionId);
+  }
+
+  static Future<List<MissionTime?>> getMissionTimes() async {
+    final times = await _missionTimeRepository.getMissionTimes();
+
+    return times;
+  }
+
+  static Future<MissionTime?> getMissionTime(int missionId) async {
+    final time = await _missionTimeRepository.getMissionTime(missionId);
 
     return time;
   }

--- a/lib/services/mission_history_service.dart
+++ b/lib/services/mission_history_service.dart
@@ -17,7 +17,7 @@ class MissionHistoryService {
   }
 
   // 미션 완료 상태 토글 및 히스토리 저장
-  static Future<bool> toggleMissionComplete(String missionId) async {
+  static Future<bool> toggleMissionComplete(int missionId) async {
     final mission = await _missionHistoryRepository.findMissionById(missionId);
 
     if (mission == null) {

--- a/lib/services/supporter_service.dart
+++ b/lib/services/supporter_service.dart
@@ -2,6 +2,7 @@ import 'package:notiyou/services/auth/auth_service.dart';
 
 import 'package:notiyou/repositories/supporter_repository.dart';
 
+// TODO: 사용 여부 확인
 class SupporterService {
   static Future<Map<String, dynamic>?> getSupporter() async {
     final user = await AuthService.getUser();

--- a/test/models/mission_test.dart
+++ b/test/models/mission_test.dart
@@ -8,8 +8,7 @@ void main() {
 
     setUp(() {
       mission = Mission(
-        id: 'test-id',
-        missionNumber: 1,
+        id: 1,
         time: const TimeOfDay(hour: 9, minute: 0),
         isCompleted: false,
         completedAt: null,
@@ -21,7 +20,6 @@ void main() {
       final copied = mission.copyWith();
 
       expect(copied.id, mission.id);
-      expect(copied.missionNumber, mission.missionNumber);
       expect(copied.time, mission.time);
       expect(copied.isCompleted, mission.isCompleted);
       expect(copied.completedAt, mission.completedAt);


### PR DESCRIPTION
## 요약

미션 타임 테이블 개편 작업을 진행합니다. 해야할 작업이 많아서 순차적으로 작업하며 PR을 올리려 합니다.

주요 변경 사항으로는...

- [refactor: supabase의 테이블명 매직 리터럴 제거](https://github.com/buku-buku/notiyou/pull/56/commits/c3a51687494f1ad1883d7929c0aff53f7dbfbe79)
- [feat: mission_time_repository에서 missionNumber 관련 의존성 제거](https://github.com/buku-buku/notiyou/pull/56/commits/93c1aa3d0722bbaf9e7b0aaea061a7157a0802a9)
- [feat: mission_history_repository에서 missionNumber 관련 의존성 제거](https://github.com/buku-buku/notiyou/pull/56/commits/c933658c5312cb5407c4d4dbb232994e558ad4f4)
- [feat: service 레이어 missionNumber 관련 의존성 제거](https://github.com/buku-buku/notiyou/pull/56/commits/33d1d94e3a8a2c8c3466b860ec3c1bc062ddbc2e)
- [feat: widget 레이어에서 missionNumber 관련 의존성 제거](https://github.com/buku-buku/notiyou/pull/56/commits/5a0169c696b9d52c668264a4cb4247a91957c2d9)

## 작업 내용

Commits on Feb 4, 2025
- [refactor: supabase의 테이블명 매직 리터럴 제거](https://github.com/buku-buku/notiyou/pull/56/commits/c3a51687494f1ad1883d7929c0aff53f7dbfbe79)

Commits on Feb 5, 2025
- [feat: mission_time_model 정의](https://github.com/buku-buku/notiyou/pull/56/commits/7aafc6fadee88afe497ad756cdf4502f3c57ff37)
- [feat: 기존 mission 모델 id 타입을 DB와 맞게 int로 변경 및 missionNumber 프로퍼티 제거](https://github.com/buku-buku/notiyou/pull/56/commits/3846133fa752df8717b6d812c4bbd80a23121d78)
- [feat: mission_time_repository에서 missionNumber 관련 의존성 제거](https://github.com/buku-buku/notiyou/pull/56/commits/93c1aa3d0722bbaf9e7b0aaea061a7157a0802a9)
- [feat: mission_history_repository에서 missionNumber 관련 의존성 제거](https://github.com/buku-buku/notiyou/pull/56/commits/c933658c5312cb5407c4d4dbb232994e558ad4f4)
- [feat: service 레이어 missionNumber 관련 의존성 제거](https://github.com/buku-buku/notiyou/pull/56/commits/33d1d94e3a8a2c8c3466b860ec3c1bc062ddbc2e)
- [feat: widget 레이어에서 missionNumber 관련 의존성 제거](https://github.com/buku-buku/notiyou/pull/56/commits/5a0169c696b9d52c668264a4cb4247a91957c2d9)
- [feat: 카카오 로그인 실패시 기존 에러를 그대로 던지도록 변경](https://github.com/buku-buku/notiyou/pull/56/commits/55c24a22ab8782a0a5b42768d8567fc6c0a62b03)
- [chore: 주석 추가](https://github.com/buku-buku/notiyou/pull/56/commits/9b1ea81bda8fbd44fd9100f59a891593a5cfd6ad)
- [test: 테스트 코드 수정](https://github.com/buku-buku/notiyou/pull/56/commits/a72886baaba5bd705808f48088432076ffe17d08)
- [chore: 불필요 코드 제거](https://github.com/buku-buku/notiyou/pull/56/commits/26ef9ea02b1c7f35f2632655a2da96aa0616192a)

Commits on Feb 6, 2025
- [Merge branch 'main' of github.com:buku-buku/notiyou into NY-102-mission-time-table](https://github.com/buku-buku/notiyou/pull/56/commits/dd5afddbe603e5210f35302be7d1e8fcf739d8b4)
- [refactor: rabbitai 리뷰 대응](https://github.com/buku-buku/notiyou/pull/56/commits/9ac9060fd62c7c7269586018d7732f346dccadd9)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새 기능**
  - 미션 시간을 생성, 업데이트, 삭제하는 기능이 추가되어 알림 예약 및 관리가 개선되었습니다.
  - 미션 시간 목록을 가져오는 기능이 추가되어 여러 미션 시간을 효율적으로 관리할 수 있습니다.
- **버그 수정**
  - 카카오 계정 로그인 시 오류 처리 방식이 개선되어 오류가 발생할 경우 적절히 처리됩니다.
- **리팩토링**
  - 미션 식별자 타입이 정수로 통일되어 데이터 일관성과 안정성이 향상되었습니다.
  - 미션 완료 처리 및 설정 인터페이스가 개선되어 사용자 경험이 강화되었습니다.
  - 데이터베이스 참조 방식이 상수화되어 코드 유지보수성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->