### PR TITLE
[NY-120] (bug) 설정 변경하면 미션 히스토리가 계속 생성되는 문제 해결

### DIFF
--- a/lib/models/mission.dart
+++ b/lib/models/mission.dart
@@ -54,7 +54,7 @@ class Mission {
 
   factory Mission.fromMissionHistoryEntity(Map<String, dynamic> json) =>
       Mission(
-        id: json['id'],
+        id: json['mission_id'],
         time: TimeUtils.parseTime(json['mission_at']),
         isCompleted: json['done_at'] != null,
         completedAt:
@@ -87,5 +87,25 @@ extension MissionHelpers on Mission {
       completedAt: completedAt?.toLocal(),
       date: date.toLocal(),
     );
+  }
+}
+
+/// @example
+/// ```dart
+/// final missions = await findMissions<Future<List<Mission>>>(DateTime.now());
+/// print('missions: ${missions.map((e) => e.debugString())}');
+/// ```
+extension MissionDebug on Mission {
+  // 🤓 debugString()이라는 임의의 메서드를 만들고, 원하는 문자열 형태로 나오도록 작성합니다
+  String debugString() {
+    return '''
+Mission {
+  id: $id,
+  time: $time,
+  isCompleted: $isCompleted,
+  completedAt: $completedAt,
+  date: $date
+}
+''';
   }
 }

--- a/lib/repositories/mission_history_repository/mission_history_repository_remote.dart
+++ b/lib/repositories/mission_history_repository/mission_history_repository_remote.dart
@@ -24,9 +24,7 @@ class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
           done_at,
           created_at,
           mission_at,
-          ${SupabaseTableNames.missionTime} (
-            id
-          )
+          mission_id
         ''')
         .eq('id', id)
         .single();
@@ -124,9 +122,7 @@ class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
           done_at,
           created_at,
           mission_at,
-          ${SupabaseTableNames.missionTime} (
-            id
-          )
+          mission_id
         ''')
           .gte('created_at', yesterday.toUtc().toIso8601String())
           .lt('created_at', tomorrow.toUtc().toIso8601String())
@@ -157,9 +153,7 @@ class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
         done_at,
         created_at,
         mission_at,
-        ${SupabaseTableNames.missionTime} (
-          id
-        )
+        mission_id
       ''');
 
     final missions = missionHistoryEntities


### PR DESCRIPTION
## 요약

### 문제 현상

1. 미션 설정 변경시 새롭게 설정된 미션으로 업데이트합니다. 
2. 이때 미션 히스토리도 함께 업데이트합니다. 단, 이미 미션 히스토리가 존재할 때만 업데이트하고 미션 히스토리가 존재하지 않으면 새로 생성합니다.
3. 그런데 2번 과정에서 미션 히스토리가 존재하지 않는다고 잘못 판단하여, 미션 히스토리가 계속 생성되는 문제가 발생했습니다.

### 문제 원인

미션 히스토리 테이블에 missionId가 존재하는지 판단할 때 missionId가 아닌 미션 히스토리의 id로 잘못 비교하고 있었기 때문입니다.

## 리뷰 요청 항목

- [fix: 설정 변경하면 미션 히스토리가 계속 생성되는 문제 해결](https://github.com/buku-buku/notiyou/pull/59/commits/148e469af72f50f5442d17242691cd640e7ed02f)


## 스크린샷

### bug

https://github.com/user-attachments/assets/e28b8115-87ed-4a40-8a27-051865237861


### fixed

https://github.com/user-attachments/assets/dc65ef2e-3246-4e6e-b6f3-41cfa6b837de



