### PR TITLE
[NY-108/feat] 도전자는 미션 생성을 완료한 이후에만 조력자를 초대할 수 있다

### DIFF
--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -188,7 +188,7 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
                 _selectedGracePeriod = newValue ?? 0;
               }),
             ),
-            const SupporterSection(),
+            if (!widget.isFirstTime) const SupporterSection(),
             buildSettingButton(
               context: context,
               label: '알림 메시지 설정',


### PR DESCRIPTION
## 요약

- 도전자는 미션 생성을 완료한 이후에만 조력자를 초대할 수 있다
- 도전자는 조력자 초대가 완료되지 않은 경우, 홈 페이지에서 조력자 초대를 요구하는 CTA 버튼을 볼 수 있다
- 도전자는 조력자 초대를 요구하는 CTA 버튼을 클릭하면, 조력자 초대 버튼이 있는 설정 페이지로 이동한다
- 도전자는 조력자 초대가 완료된 경우, 홈 페이지에서 함께 하는 조력자의 정보를 볼 수 있다

## 리뷰 요청 항목

- [feat: 설정 페이지에 처음 진입한 경우 서포터 초대 UI를 보여주지 않는다](https://github.com/buku-buku/notiyou/pull/62/commits/561b6cb6d3823ea9923802da9ae1223db7b34a30)
- [feat: 홈 화면에 조력자 초대 완료 여부에 따른 AlertBanner 표시](https://github.com/buku-buku/notiyou/pull/62/commits/5110b2ec19e3a825e705fc3e927ec101201082b9)

## 기타 사항

- 조력자를 식별할 수 있는 닉네임이나 부가 정보가 꼭 있어야겠어요. 함께 하는 조력자 정보를 uuid로 보여줄 수는 없으니..
- #61 에 이어서 작업한 브랜치입니다.

## 스크린샷

> 도전자는 미션 생성을 완료한 이후에만 조력자를 초대할 수 있다

<img width="525" alt="image" src="https://github.com/user-attachments/assets/b30eb713-0344-4aa8-a183-e007a630ea06" />


> 도전자는 조력자 초대가 완료되지 않은 경우, 홈 페이지에서 조력자 초대를 요구하는 CTA 버튼을 볼 수 있다

<img width="525" alt="image" src="https://github.com/user-attachments/assets/d1830996-45c8-4feb-a39e-9f3c91cb7080" />

> 도전자는 조력자 초대를 요구하는 CTA 버튼을 클릭하면, 조력자 초대 버튼이 있는 설정 페이지로 이동한다

https://github.com/user-attachments/assets/054d357f-2616-4a4c-8f74-b34a9291eba9

> 도전자는 조력자 초대가 완료된 경우, 홈 페이지에서 함께 하는 조력자의 정보를 볼 수 있다

<img width="525" alt="image" src="https://github.com/user-attachments/assets/47cd0dab-33e7-414a-a040-d87bef353a84" />
