### PR TITLE
[NY-141] 초대링크 routing과 관련된 버그 2개 대응

### DIFF
--- a/lib/routes/router.dart
+++ b/lib/routes/router.dart
@@ -5,9 +5,13 @@ import 'package:notiyou/screens/login_page.dart';
 import 'package:notiyou/screens/splash_page.dart';
 import 'package:notiyou/screens/supporter_signup_page.dart';
 import 'package:notiyou/services/invite_deep_link_service.dart';
+import 'package:flutter/foundation.dart';
+
+final routerRefreshNotifier = ValueNotifier<bool>(false);
 
 final router = GoRouter(
   initialLocation: SplashPage.routeName,
+  refreshListenable: routerRefreshNotifier,
   redirect: (context, state) async {
     final inviteDeepLink = InviteDeepLinkService.pendingDeepLink;
 

--- a/lib/screens/supporter_signup_page.dart
+++ b/lib/screens/supporter_signup_page.dart
@@ -32,7 +32,7 @@ class _SupporterSignupPageState extends State<SupporterSignupPage> {
   Timer? _debounceTimer;
   bool _isValidated = false;
 
-  void _initializeCode(String? code) {
+  void _updateCode(String? code) {
     if (code?.isNotEmpty ?? false) {
       _challengerCodeController.text = code!;
       _validateChallengerCode(code);
@@ -44,14 +44,14 @@ class _SupporterSignupPageState extends State<SupporterSignupPage> {
     super.initState();
     _challengerCodeController = TextEditingController();
     _challengerCodeController.addListener(_onCodeChanged);
-    _initializeCode(widget.initialChallengerCode);
+    _updateCode(widget.initialChallengerCode);
   }
 
   @override
   void didUpdateWidget(SupporterSignupPage oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.initialChallengerCode != oldWidget.initialChallengerCode) {
-      _initializeCode(widget.initialChallengerCode);
+      _updateCode(widget.initialChallengerCode);
     }
   }
 

--- a/lib/screens/supporter_signup_page.dart
+++ b/lib/screens/supporter_signup_page.dart
@@ -32,16 +32,26 @@ class _SupporterSignupPageState extends State<SupporterSignupPage> {
   Timer? _debounceTimer;
   bool _isValidated = false;
 
+  void _initializeCode(String? code) {
+    if (code?.isNotEmpty ?? false) {
+      _challengerCodeController.text = code!;
+      _validateChallengerCode(code);
+    }
+  }
+
   @override
   void initState() {
     super.initState();
-    _challengerCodeController =
-        TextEditingController(text: widget.initialChallengerCode);
+    _challengerCodeController = TextEditingController();
     _challengerCodeController.addListener(_onCodeChanged);
+    _initializeCode(widget.initialChallengerCode);
+  }
 
-    // 초기 코드가 있는 경우 검증 실행
-    if (widget.initialChallengerCode?.isNotEmpty ?? false) {
-      _validateChallengerCode(widget.initialChallengerCode!);
+  @override
+  void didUpdateWidget(SupporterSignupPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.initialChallengerCode != oldWidget.initialChallengerCode) {
+      _initializeCode(widget.initialChallengerCode);
     }
   }
 

--- a/lib/services/invite_deep_link_service.dart
+++ b/lib/services/invite_deep_link_service.dart
@@ -3,6 +3,7 @@ import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_service.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_service_interface.dart';
 import 'package:notiyou/services/dotenv_service.dart';
+import 'package:notiyou/routes/router.dart';
 
 enum InvitedUserStatus {
   guest,
@@ -58,7 +59,10 @@ class InviteDeepLinkService {
 
   static void _listenToDeepLinks() {
     _appLinks.uriLinkStream.listen(
-      _processDeepLink,
+      (uri) async {
+        await _processDeepLink(uri);
+        routerRefreshNotifier.value = !routerRefreshNotifier.value;
+      },
       onError: (error) => _resetToDefaultState(error),
     );
   }


### PR DESCRIPTION
## 요약
### 문제1
- 상황 
  - ios 환경에서, 백그라운드에 앱이 실행된 상태에서 초대링크를 클릭했을 때 초대코드입력으로 페이지가 자동 전환되지 않던 문제
-  원인
  - ios에서 백그라운드에서 포그라운드로 앱이 넘어올 때 라우터가 redirect를 트리거 하지 못함
- 해결 방안
  - goRouter의 `refreshListenable`이라는 것을 사용하여 앱이 포그라운드로 전환되면 이를 라우터에게 알려서 redirect를 강제 트리거
  - 커서의 도움으로 알게되었으나 `refreshListenable`는 문서에는 설명이 없네요..

### 문제2
- 상황
  - 사용자가 이미 SupporterSignUp 페이지에 있는 상황에서(빈 code input), 초대링크를 클릭한 경우 input이 challengerCode로 채워지지 않음
- 원인
  - `Go Router는 기본적으로 현재 페이지와 동일한 경로로 이동하려고 할 때, 새로운 파라미터가 있더라도 페이지를 다시 빌드하지 않습니다.` 라고 함. 그래서 initState가 실행되지 않은듯.
- 해결 방안
  - `didUpdateWidget` 라는 라이프라이클훅에서 initializeCode를 실행하도록 하여, 같은 페이지로 routing이 되어도 코드가 채워지도록 대응

## 작업 내용
- 문제1: [feat: routerRefreshNotifier를 추가하여 router를 수동으로 refresh](https://github.com/buku-buku/notiyou/pull/77/commits/2c72ca55b132424e0c7cb831c5279350651c755f)
- 문제2: [fix: 동일한 페이지에 있을 때 code update를 감지못하는 것 해결](https://github.com/buku-buku/notiyou/pull/77/commits/6d9ec57ed579606de403eacfa2aca907dd21c279)

## 체크리스트

- android에서 동작 변경이 있는지 확인 필요



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 앱 네비게이션이 실시간 상태 변화를 감지하여 자동 새로 고침됩니다.
  
- **리팩토링**
  - 지원자 가입 화면의 입력 초기화 및 검증 로직이 중앙 집중화되어 안정성이 향상되었습니다.
  - 초대 링크 처리가 완료된 후 네비게이션 상태 갱신 흐름이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->