### PR TITLE
[NY-144] 홈 화면이 loadPartner 함수 에러 때문에 보이지 않는 문제 해결

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -44,7 +44,7 @@ class _HomePageState extends State<HomePage> {
 
     final [missions, partner] = await Future.wait([
       _loadMissions(),
-      _loadPartner(),
+      _loadPartner(userRole),
     ]);
 
     if (!mounted) return;
@@ -59,10 +59,33 @@ class _HomePageState extends State<HomePage> {
     return await MissionHistoryService.getTodaysMissions();
   }
 
-  Future<ChallengerSupporter?> _loadPartner() async {
-    return _userRole == UserRole.challenger
+  Future<ChallengerSupporter?> _loadPartner(UserRole userRole) async {
+    return userRole == UserRole.challenger
         ? await ChallengerSupporterService.getSupporter()
         : await ChallengerSupporterService.getChallenger();
+  }
+
+  Future<void> _toggleMissionComplete(int missionId) async {
+    final newState =
+        await MissionHistoryService.toggleMissionComplete(missionId);
+    setState(() {
+      final updatedMissions = _missions.map((mission) {
+        if (mission.id == missionId) {
+          return Mission(
+            id: mission.id,
+            time: mission.time,
+            isCompleted: newState,
+            completedAt: newState ? DateTime.now() : null,
+            date: mission.date,
+          );
+        }
+        return mission;
+      }).toList();
+      _missions = updatedMissions;
+    });
+
+    // 미션 상태 변경 후 만료 상태와 완료 시간 다시 로드
+    _loadMissions();
   }
 
   @override
@@ -87,29 +110,6 @@ class _HomePageState extends State<HomePage> {
         ],
       ),
     );
-  }
-
-  Future<void> _toggleMissionComplete(int missionId) async {
-    final newState =
-        await MissionHistoryService.toggleMissionComplete(missionId);
-    setState(() {
-      final updatedMissions = _missions.map((mission) {
-        if (mission.id == missionId) {
-          return Mission(
-            id: mission.id,
-            time: mission.time,
-            isCompleted: newState,
-            completedAt: newState ? DateTime.now() : null,
-            date: mission.date,
-          );
-        }
-        return mission;
-      }).toList();
-      _missions = updatedMissions;
-    });
-
-    // 미션 상태 변경 후 만료 상태와 완료 시간 다시 로드
-    _loadMissions();
   }
 }
 


### PR DESCRIPTION
## 요약

홈 화면이 loadPartner 함수 에러 때문에 보이지 않는 문제를 해결합니다.

## 작업 내용

<!-- slot-start -->

- [fix: loadPartner 함수에서 참조하는 값이 null이라서 발생하는 에러 해결](https://github.com/buku-buku/notiyou/pull/78/commits/d1c4bfc38cfd3ebf98f5a1ef42cec2bb3a10f197)

<!-- slot-end -->

## 기타 사항

### 에러 재현
- 챌린저로 가입한다
- 홈화면에서 아무것도 보이지 않는다
- 디버그 콘솔에서 다음과 같은 PostgreSQL 에러가 발생하고 있었다

```
PostgrestException (PostgrestException(message: JSON object requested, multiple (or no) rows returned, code: PGRST116, details: The result contains 0 rows, hint: null))
```

### 에러 원인

> [해당 PR](https://github.com/buku-buku/notiyou/pull/68/files#diff-49c735a288bc9b07cec61ebd9915b04b70cb9baa3ebf6e2183fe859e0af65d82)



<img src="https://github.com/user-attachments/assets/8ea2df7c-fa1a-4882-b87f-825eab3b53ff" width="600" />


## 스크린샷


### Before (에러)

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/cc7c4a13-0bd0-4246-9597-bf304178dc1a" />



### After (정상 동작)


https://github.com/user-attachments/assets/10bf8449-cf83-429e-bf80-2dff74ce9075




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 미션 완료 상태 토글 기능이 개선되어, 미션 진행 상황이 더 빠르고 정확하게 반영됩니다.  
    사용자는 미션 완료 및 미완료 상태를 손쉽게 전환할 수 있으며, 업데이트된 UI 반응 속도를 통해 개선된 사용자 경험을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->