### PR TITLE
fix: 서버에 미션 시간이 utc 기준으로 기록되도록 수정

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // IntelliSense를 사용하여 가능한 특성에 대해 알아보세요.
+  // 기존 특성에 대한 설명을 보려면 가리킵니다.
+  // 자세한 내용을 보려면 https://go.microsoft.com/fwlink/?linkid=830387을(를) 방문하세요.
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "notiyou",
+      "request": "launch",
+      "type": "dart"
+    },
+    {
+      "name": "notiyou (profile mode)",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "profile"
+    },
+    {
+      "name": "notiyou (release mode)",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "release"
+    }
+  ]
+}

--- a/lib/repositories/mission_history_repository/mission_history_repository_remote.dart
+++ b/lib/repositories/mission_history_repository/mission_history_repository_remote.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:notiyou/models/mission.dart';
-import 'package:notiyou/repositories/supabase_table_names_constants.dart';
 import 'package:notiyou/repositories/mission_history_repository/mission_history_repository_interface.dart';
+import 'package:notiyou/repositories/supabase_table_names_constants.dart';
 import 'package:notiyou/services/supabase_service.dart';
 import 'package:notiyou/utils/time_utils.dart';
 
@@ -64,7 +64,7 @@ class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
   @override
   Future<void> updateMission(Mission mission) async {
     final (today, tomorrow) = _getTodayAndTomorrow();
-    var result;
+    dynamic result;
     if (mission.completedAt == null) {
       result = await SupabaseService.client
           .from(SupabaseTableNames.missionHistory)
@@ -83,7 +83,7 @@ class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
           .gte('created_at', today.toUtc().toIso8601String());
     }
 
-    print('result: $result');
+    return result;
   }
 
   @override

--- a/lib/repositories/mission_history_repository/mission_history_repository_remote.dart
+++ b/lib/repositories/mission_history_repository/mission_history_repository_remote.dart
@@ -15,8 +15,17 @@ import 'package:notiyou/utils/time_utils.dart';
 /// ⚠️: 로컬의 데이터는 오늘의 데이터만 저장됩니다.
 /// 오늘 이후의 모든 데이터는 앱 실행 시 삭제됩니다.
 class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
+  (DateTime, DateTime) _getTodayAndTomorrow() {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final tomorrow = today.add(const Duration(days: 1));
+    return (today, tomorrow);
+  }
+
   @override
   Future<Mission?> findMissionById(int id) async {
+    final (today, tomorrow) = _getTodayAndTomorrow();
+
     final entity = await SupabaseService.client
         .from(SupabaseTableNames.missionHistory)
         .select('''
@@ -26,7 +35,9 @@ class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
           mission_at,
           mission_id
         ''')
-        .eq('id', id)
+        .eq('mission_id', id)
+        .gte('created_at', today.toUtc().toIso8601String())
+        .lt('created_at', tomorrow.toUtc().toIso8601String())
         .single();
 
     return Mission.fromMissionHistoryEntity(entity);
@@ -52,19 +63,27 @@ class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
 
   @override
   Future<void> updateMission(Mission mission) async {
+    final (today, tomorrow) = _getTodayAndTomorrow();
+    var result;
     if (mission.completedAt == null) {
-      await SupabaseService.client
+      result = await SupabaseService.client
           .from(SupabaseTableNames.missionHistory)
           .update({
-        'done_at': null,
-      }).eq('id', mission.id);
+            'done_at': null,
+          })
+          .eq('mission_id', mission.id)
+          .gte('created_at', today.toUtc().toIso8601String());
     } else {
-      await SupabaseService.client
+      result = await SupabaseService.client
           .from(SupabaseTableNames.missionHistory)
           .update({
-        'done_at': mission.completedAt!.toUtc().toIso8601String(),
-      }).eq('id', mission.id);
+            'done_at': mission.completedAt!.toUtc().toIso8601String(),
+          })
+          .eq('mission_id', mission.id)
+          .gte('created_at', today.toUtc().toIso8601String());
     }
+
+    print('result: $result');
   }
 
   @override
@@ -72,7 +91,7 @@ class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
     final missionTime = await SupabaseService.client
         .from(SupabaseTableNames.missionTime)
         .select('id, mission_at')
-        .eq('id', missionId)
+        .eq('mission_id', missionId)
         .single();
 
     await SupabaseService.client
@@ -91,8 +110,8 @@ class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
 
   @override
   Future<void> updateTodayMissionTime(int missionId, TimeOfDay time) async {
-    final now = DateTime.now();
-    final today = DateTime(now.year, now.month, now.day);
+    final (today, tomorrow) = _getTodayAndTomorrow();
+
     final mission = await SupabaseService.client
         .from(SupabaseTableNames.missionTime)
         .select('id')
@@ -102,7 +121,7 @@ class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
     await SupabaseService.client
         .from(SupabaseTableNames.missionHistory)
         .update({
-          'mission_at': TimeUtils.stringifyTime(time),
+          'mission_at': TimeUtils.stringifyTimeWithUTC(time),
         })
         .eq('mission_id', mission['id'])
         .gte('created_at', today.toUtc().toIso8601String());

--- a/lib/repositories/mission_time_repository/mission_time_repository_remote.dart
+++ b/lib/repositories/mission_time_repository/mission_time_repository_remote.dart
@@ -141,7 +141,7 @@ class MissionTimeRepositoryRemote implements MissionTimeRepository {
     final mission =
         await supabaseClient.from(SupabaseTableNames.missionTime).insert({
       'challenger_supporter_id': challengerSupporter.id,
-      'mission_at': TimeUtils.stringifyTime(time),
+      'mission_at': TimeUtils.stringifyTimeWithUTC(time),
     }).select('''
             id, 
             created_at, 
@@ -182,8 +182,10 @@ class MissionTimeRepositoryRemote implements MissionTimeRepository {
         .eq('${SupabaseTableNames.challengerSupporter}.challenger_id', userId)
         .single();
 
-    await supabaseClient.from(SupabaseTableNames.missionTime).update(
-        {'mission_at': TimeUtils.stringifyTime(time)}).eq('id', mission['id']);
+    await supabaseClient
+        .from(SupabaseTableNames.missionTime)
+        .update({'mission_at': TimeUtils.stringifyTimeWithUTC(time)}).eq(
+            'id', mission['id']);
   }
 
   // 미션 시간 초기화

--- a/lib/utils/time_utils.dart
+++ b/lib/utils/time_utils.dart
@@ -7,11 +7,34 @@ class TimeUtils {
     return '${time.hour}:${time.minute}';
   }
 
+  static String stringifyTimeWithUTC(TimeOfDay time) {
+    final now = DateTime.now();
+    final offset = now.timeZoneOffset;
+    final utcTime = DateTime(
+      now.year,
+      now.month,
+      now.day,
+      time.hour,
+      time.minute,
+    ).subtract(offset);
+    return '${utcTime.hour}:${utcTime.minute}';
+  }
+
   // 문자열을 시간 객체로 변환
   static TimeOfDay parseTime(String timeStr) {
     final hour = int.parse(timeStr.split(':')[0]);
     final minute = int.parse(timeStr.split(':')[1]);
-    return TimeOfDay(hour: hour, minute: minute);
+    final offset = int.parse(timeStr.split('+')[1]);
+    final now = DateTime.now();
+    final localOffset = now.timeZoneOffset;
+    final localTime = DateTime(
+      now.year,
+      now.month,
+      now.day,
+      hour,
+      minute,
+    ).add(Duration(hours: (offset - localOffset.inHours).abs()));
+    return TimeOfDay(hour: localTime.hour, minute: localTime.minute);
   }
 
   static bool isDateString(String dateStr) {


### PR DESCRIPTION
## 요약

클라이언트에서  DB에 미션 시간을 저장할때, 기기의 로컬 시간을 timezone을 누락한채로 서버에 저장하고 있습니다.
때문에 적절한 시간대에 remote notification 전송이 이루어지지 않았습니다.

DB 미션 시간 저장시, 일관되게 utc 기준으로 시간을 변환하여 저장하도록 수정합니다.

## 작업 내용

Commits on Mar 16, 2025
- [fix: 서버에 미션 시간이 utc 기준으로 기록되도록 수정](https://github.com/buku-buku/notiyou/pull/81/commits/71198471fdfea0e1d2ec2dbe6b43628402b2ad5a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

이번 업데이트에서는 미션 기록 및 시간 정보 표시 방식이 개선되어 사용자에게 보다 정확하고 일관된 데이터를 제공합니다.

- **New Features**
  - 미션 기록 조회 시 오늘 생성된 항목만 정확하게 필터링되어 표시됩니다.
  - 미션 시간 정보가 UTC 기준으로 표준화되어, 국제 표준 시간에 맞춘 정확한 시간 정보가 제공됩니다.
  - Dart 애플리케이션을 위한 새로운 실행 구성 파일이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->