### PR TITLE
[NY-142] 홈 화면 UI에 카카오톡 프로필 이름을 사용하도록 개선

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,6 +20,12 @@
       "request": "launch",
       "type": "dart",
       "flutterMode": "release"
+    },
+    {
+      "name": "Dart: Run all Tests",
+      "type": "dart",
+      "request": "launch",
+      "program": "./test/"
     }
   ]
 }

--- a/lib/entities/current_participant.dart
+++ b/lib/entities/current_participant.dart
@@ -1,0 +1,29 @@
+class CurrentParticipant {
+  final String name;
+  final ParticipantType type;
+  final Partner? partner;
+
+  const CurrentParticipant({
+    required this.name,
+    required this.type,
+    this.partner,
+  });
+
+  bool get isChallenger => type == ParticipantType.challenger;
+  bool get isSupporter => type == ParticipantType.supporter;
+}
+
+enum ParticipantType {
+  challenger,
+  supporter,
+}
+
+class Partner {
+  final String name;
+  final ParticipantType type;
+
+  const Partner({
+    required this.name,
+    required this.type,
+  });
+}

--- a/lib/repositories/mission_history_repository/mission_history_repository_remote.dart
+++ b/lib/repositories/mission_history_repository/mission_history_repository_remote.dart
@@ -91,7 +91,7 @@ class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
     final missionTime = await SupabaseService.client
         .from(SupabaseTableNames.missionTime)
         .select('id, mission_at')
-        .eq('mission_id', missionId)
+        .eq('id', missionId)
         .single();
 
     await SupabaseService.client

--- a/lib/repositories/participant_repository/participant_repository_interface.dart
+++ b/lib/repositories/participant_repository/participant_repository_interface.dart
@@ -1,0 +1,9 @@
+import 'package:notiyou/entities/current_participant.dart';
+
+abstract interface class ParticipantRepository {
+  /// 현재 사용자의 Participant 정보를 가져옵니다.
+  Future<CurrentParticipant> getCurrentParticipant();
+
+  /// 특정 사용자의 Participant 정보를 가져옵니다.
+  Future<CurrentParticipant> getParticipantById(String userId);
+}

--- a/lib/repositories/participant_repository/participant_repository_remote.dart
+++ b/lib/repositories/participant_repository/participant_repository_remote.dart
@@ -1,0 +1,79 @@
+import 'package:notiyou/entities/current_participant.dart';
+import 'package:notiyou/repositories/participant_repository/participant_repository_interface.dart';
+import 'package:notiyou/repositories/supabase_table_names_constants.dart';
+import 'package:notiyou/services/supabase_service.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class ParticipantRepositoryRemote implements ParticipantRepository {
+  static final ParticipantRepositoryRemote _instance =
+      ParticipantRepositoryRemote._internal();
+
+  ParticipantRepositoryRemote._internal();
+
+  factory ParticipantRepositoryRemote() {
+    return _instance;
+  }
+
+  static final supabaseClient = SupabaseService.client;
+
+  @override
+  Future<CurrentParticipant> getCurrentParticipant() async {
+    final userId = supabaseClient.auth.currentUser?.id;
+    if (userId == null) {
+      throw const AuthException('User not found');
+    }
+
+    return getParticipantById(userId);
+  }
+
+  @override
+  Future<CurrentParticipant> getParticipantById(String userId) async {
+    final currentUserMetadata = await supabaseClient
+        .from(SupabaseTableNames.userMetadata)
+        .select()
+        .eq('id', userId)
+        .single();
+
+    final challengerSupporter = await supabaseClient
+        .from(SupabaseTableNames.challengerSupporter)
+        .select('challenger_id, supporter_id')
+        .or('challenger_id.eq.$userId,supporter_id.eq.$userId')
+        .maybeSingle();
+
+    final hasChallengerSupporter = challengerSupporter != null;
+    final isUserChallenger = hasChallengerSupporter &&
+        userId == challengerSupporter['challenger_id'];
+
+    String? partnerId;
+    if (hasChallengerSupporter) {
+      partnerId = isUserChallenger
+          ? challengerSupporter['supporter_id']
+          : challengerSupporter['challenger_id'];
+    }
+
+    Partner? partner;
+    final hasPartner = partnerId != null;
+    if (hasPartner) {
+      final partnerMetadata = await supabaseClient
+          .from(SupabaseTableNames.userMetadata)
+          .select()
+          .eq('id', partnerId)
+          .single();
+
+      partner = Partner(
+        type: isUserChallenger
+            ? ParticipantType.supporter
+            : ParticipantType.challenger,
+        name: partnerMetadata['name'],
+      );
+    }
+
+    return CurrentParticipant(
+      name: currentUserMetadata['name'],
+      type: isUserChallenger
+          ? ParticipantType.challenger
+          : ParticipantType.supporter,
+      partner: partner,
+    );
+  }
+}

--- a/lib/repositories/user_metadata_repository/user_metadata_repository_interface.dart
+++ b/lib/repositories/user_metadata_repository/user_metadata_repository_interface.dart
@@ -1,4 +1,6 @@
 abstract class UserMetadataRepository {
   Future<void> setFCMToken(String token);
   Future<String?> getFCMToken();
+  Future<void> setName(String name);
+  Future<String?> getName();
 }

--- a/lib/repositories/user_metadata_repository/user_metadata_repository_remote.dart
+++ b/lib/repositories/user_metadata_repository/user_metadata_repository_remote.dart
@@ -57,4 +57,48 @@ class UserMetadataRepositoryRemote implements UserMetadataRepository {
     final data = userMetadata.first;
     return data['fcm_token'];
   }
+
+  @override
+  Future<void> setName(String name) async {
+    final userId = supabaseClient.auth.currentUser?.id;
+    if (userId == null) {
+      throw const AuthException('User not found');
+    }
+
+    final userMetadata = await supabaseClient
+        .from(SupabaseTableNames.userMetadata)
+        .select()
+        .eq('id', userId);
+
+    if (userMetadata.isEmpty) {
+      await supabaseClient.from(SupabaseTableNames.userMetadata).insert({
+        'id': userId,
+        'name': name,
+      });
+    } else {
+      await supabaseClient.from(SupabaseTableNames.userMetadata).update({
+        'name': name,
+      }).eq('id', userId);
+    }
+  }
+
+  @override
+  Future<String?> getName() async {
+    final userId = supabaseClient.auth.currentUser?.id;
+    if (userId == null) {
+      return null;
+    }
+
+    final userMetadata = await supabaseClient
+        .from(SupabaseTableNames.userMetadata)
+        .select()
+        .eq('id', userId);
+
+    if (userMetadata.isEmpty) {
+      return null;
+    }
+
+    final data = userMetadata.first;
+    return data['name'];
+  }
 }

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:notiyou/models/challenger_supporter_model.dart';
+import 'package:notiyou/entities/current_participant.dart';
 import 'package:notiyou/models/mission.dart';
-import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/screens/challenger_config_page.dart';
 import 'package:notiyou/screens/signup_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
-import 'package:notiyou/services/challenger_config_service.dart';
 import 'package:notiyou/services/mission_history_service.dart';
+import 'package:notiyou/services/participant_service.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -20,46 +19,37 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   List<Mission> _missions = [];
-  ChallengerSupporter? _missionPartner;
-  UserRole? _userRole;
+  CurrentParticipant? _participant;
+  final _participantService = ParticipantService.getInstance();
 
   @override
   void initState() {
     super.initState();
-    _initPageViewByRole();
+    _initPageView();
   }
 
-  Future<void> _initPageViewByRole() async {
+  Future<void> _initPageView() async {
     final user = await AuthService.getUserSafe();
-
-    final userRole = AuthService.getRegistrationStatus(user).registeredRole;
-    if (userRole == UserRole.none) {
+    if (user.userMetadata == null) {
       if (!mounted) return;
       context.go(SignupPage.routeName);
       return;
     }
 
-    final [missions, partner] = await Future.wait([
+    final [missions, participant] = await Future.wait([
       _loadMissions(),
-      _loadPartner(userRole),
+      _participantService.getCurrentParticipant(),
     ]);
 
     if (!mounted) return;
     setState(() {
-      _userRole = userRole;
       _missions = missions as List<Mission>;
-      _missionPartner = partner as ChallengerSupporter?;
+      _participant = participant as CurrentParticipant;
     });
   }
 
   Future<List<Mission>> _loadMissions() async {
     return await MissionHistoryService.getTodaysMissions();
-  }
-
-  Future<ChallengerSupporter?> _loadPartner(UserRole userRole) async {
-    return userRole == UserRole.challenger
-        ? await ChallengerConfigService.getSupporter()
-        : await ChallengerConfigService.getChallenger();
   }
 
   Future<void> _toggleMissionComplete(int missionId) async {
@@ -87,21 +77,29 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
+    if (_participant == null) {
+      return const Scaffold(
+        body: Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Home')),
+      appBar: AppBar(title: Text('${_participant!.name}님의 Home')),
       body: ListView(
         children: [
-          if (_userRole == UserRole.challenger)
+          if (_participant!.isChallenger)
             buildChallengerView(
               context,
-              _missionPartner,
+              _participant!.partner,
               _missions,
               _toggleMissionComplete,
             ),
-          if (_userRole == UserRole.supporter)
+          if (_participant!.isSupporter)
             buildSupporterView(
               context,
-              _missionPartner,
+              _participant!.partner,
               _missions,
             ),
         ],
@@ -112,16 +110,16 @@ class _HomePageState extends State<HomePage> {
 
 Widget buildSupporterAlertBannerForChallenger({
   required BuildContext context,
-  required ChallengerSupporter? supporter,
+  required Partner? supporter,
 }) {
-  final hasSupporter = supporter?.supporterId != null;
+  final hasSupporter = supporter != null;
 
   return Container(
     color: hasSupporter ? Colors.green[100] : Colors.red[100],
     padding: const EdgeInsets.all(16.0),
     child: hasSupporter
         ? Text(
-            '조력자 ${supporter?.supporterId}님과 함께 하고 있습니다.',
+            '조력자 ${supporter.name}님과 함께 하고 있습니다.',
           )
         : Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -161,7 +159,7 @@ Widget buildSupporterAlertBannerForChallenger({
 
 Widget buildChallengerView(
   BuildContext context,
-  ChallengerSupporter? supporter,
+  Partner? supporter,
   List<Mission> missions,
   Future<void> Function(int) onToggleMissionComplete,
 ) {
@@ -218,19 +216,19 @@ Widget buildChallengerView(
 
 Widget buildChallengerInfoBannerForSupporter({
   required BuildContext context,
-  required ChallengerSupporter? challenger,
+  required Partner? challenger,
 }) {
   return Container(
       color: Colors.green[100],
       padding: const EdgeInsets.all(16.0),
       child: Text(
-        '도전자 ${challenger?.challengerId}님과 함께 하고 있습니다.',
+        '도전자 ${challenger?.name}님과 함께 하고 있습니다.',
       ));
 }
 
 Widget buildSupporterView(
   BuildContext context,
-  ChallengerSupporter? challenger,
+  Partner? challenger,
   List<Mission> missions,
 ) {
   return Column(

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -118,8 +118,11 @@ Widget buildSupporterAlertBannerForChallenger({
     color: hasSupporter ? Colors.green[100] : Colors.red[100],
     padding: const EdgeInsets.all(16.0),
     child: hasSupporter
-        ? Text(
-            '조력자 ${supporter.name}님과 함께 하고 있습니다.',
+        ? SizedBox(
+            width: double.infinity,
+            child: Text(
+              '조력자 ${supporter.name}님과 함께 하고 있습니다.',
+            ),
           )
         : Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/services/auth/kakao_auth_service.dart
+++ b/lib/services/auth/kakao_auth_service.dart
@@ -33,6 +33,10 @@ class KakaoAuthService {
         : _loginWithKakaoAccount();
   }
 
+  static Future<kakao.User?> getUser() async {
+    return await _kakaoUserApi.me();
+  }
+
   static void validateTokenForSupabaseLink(kakao.OAuthToken token) {
     final userIdToken = token.idToken;
     if (userIdToken == null) {

--- a/lib/services/participant_service.dart
+++ b/lib/services/participant_service.dart
@@ -1,0 +1,26 @@
+import 'package:notiyou/entities/current_participant.dart';
+import 'package:notiyou/repositories/participant_repository/participant_repository_interface.dart';
+import 'package:notiyou/repositories/participant_repository/participant_repository_remote.dart';
+
+class ParticipantService {
+  final ParticipantRepository _repository;
+
+  const ParticipantService(this._repository);
+
+  /// todo(@datalater): Service 레이어가 Repository 구현체에 의존하지 않도록 나중에 수정해야 합니다.
+  static final ParticipantService _instance = ParticipantService(
+    ParticipantRepositoryRemote(),
+  );
+
+  factory ParticipantService.getInstance() {
+    return _instance;
+  }
+
+  Future<CurrentParticipant> getCurrentParticipant() async {
+    return await _repository.getCurrentParticipant();
+  }
+
+  Future<CurrentParticipant> getParticipantById(String userId) async {
+    return await _repository.getParticipantById(userId);
+  }
+}

--- a/test/services/participant_service_test.dart
+++ b/test/services/participant_service_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:notiyou/entities/current_participant.dart';
+import 'package:notiyou/repositories/participant_repository/participant_repository_interface.dart';
+import 'package:notiyou/services/participant_service.dart';
+
+class MockParticipantRepository extends Mock implements ParticipantRepository {}
+
+void main() {
+  late ParticipantRepository mockRepository;
+  late ParticipantService service;
+
+  setUp(() {
+    mockRepository = MockParticipantRepository();
+    service = ParticipantService(mockRepository);
+  });
+
+  group('ParticipantService', () {
+    test('getCurrentParticipant returns Participant from repository', () async {
+      const expectedParticipant = CurrentParticipant(
+        name: 'Test User',
+        type: ParticipantType.challenger,
+        partner: Partner(
+          name: 'Test Partner',
+          type: ParticipantType.supporter,
+        ),
+      );
+
+      when(() => mockRepository.getCurrentParticipant())
+          .thenAnswer((_) async => expectedParticipant);
+
+      final result = await service.getCurrentParticipant();
+
+      expect(result.name, equals(expectedParticipant.name));
+      expect(result.partner?.name, equals(expectedParticipant.partner?.name));
+      expect(result.partner?.type, equals(expectedParticipant.partner?.type));
+      verify(() => mockRepository.getCurrentParticipant()).called(1);
+    });
+  });
+}


### PR DESCRIPTION
## 요약

홈 화면 UI에 카카오톡 프로필 이름을 사용하도록 개선합니다.

## 작업 내용

<!-- slot-start -->

- [chore: vscode/launch.json에 Run All Tests 추가](https://github.com/buku-buku/notiyou/pull/83/commits/51dac251e49f73f0cdd09ced35292d6a10359dca)
- [feat: 카카오톡 로그인 완료하면 user_metadata에 카톡 프로필 이름 저장](https://github.com/buku-buku/notiyou/pull/83/commits/734222f4be79776c905dcee4e55945a7166035f7)
- [feat: CurrentParticipant Entity 추가](https://github.com/buku-buku/notiyou/pull/83/commits/2a513f7e6d20b7b63ea2defd86bbe9b9b5f23673)
  - (이름 변경) Participant => CurrentParticipant (isMe 프로퍼티 필요 없도록)
  - (타입 유지) Partner 타입을 Participant 타입으로 변경하면 순환 참조될 수 있습니다(ex. `participant.partner.partner.partner....`). 단방향으로 사용하는 것이 더 간단하므로 기존 Partner 타입 그대로 유지합니다.
- [spec: ParticipantServiceTest 추가](https://github.com/buku-buku/notiyou/pull/83/commits/03ab56b0662940855fc2913cc30fd3a7a6049435)
- [feat: ParticipantService 및 ParticipantRepository 추가](https://github.com/buku-buku/notiyou/pull/83/commits/7f654f67a529bd83d74ea7f45df299ad46a8c2b5)
- [feat: UI 레이어 HomePage가 entity를 사용해서 챌린저 및 조력자 이름 표시](https://github.com/buku-buku/notiyou/pull/83/commits/cab70aca9562ed70891c3df74e8a18b1cc7e8a0a)
- [style: 함께 하고 있는 조력자 UI를 전체 너비로 변경](https://github.com/buku-buku/notiyou/pull/83/commits/2256d5c5563b7b31fa6513a7b786a2289ea0a137)
- [feat: 서포터 초대 링크에 챌린저 이름 표시 및 챌린저 설정 페이지에 조력자 이름 표시](https://github.com/buku-buku/notiyou/pull/83/commits/34494cdca8201191733bac62ccdf17cbb2896f8b)

<!-- slot-end -->


### DB

user_metadata 테이블에 RLS policy를 추가했습니다:

> 이 정책이 없으면 아래 에러가 발생합니다:
>
> ```
> PostgrestException(message: JSON object requested, multiple (or no) rows returned, code: PGRST116, details: The result contains 0 rows, hint: null)
> ```

```sql
-- Enable users can see their partner records
-- 사용자는 파트너의 record를 select할 수 있습니다
alter policy "Enable users can see their partner records"
on "public"."user_metadata"
to authenticated
using (
  ((auth.uid() = id) OR (EXISTS ( SELECT 1
   FROM challenger_supporter cs
  WHERE (((cs.challenger_id = auth.uid()) AND (cs.supporter_id = user_metadata.id)) OR ((cs.supporter_id = auth.uid()) AND (cs.challenger_id = user_metadata.id))))))
);

```

## 기타 사항

- TODO 주석이 있습니다.
  - `todo(@datalater): Service 레이어가 Repository 구현체에 의존하지 않도록 나중에 수정해야 합니다.`
- 카카오톡 프로필 이름을 쓸 만한 UI가 더 남아 있어서 후속으로 작업할 예정입니다
  - 챌린저가 서포터 초대하기로 카카오톡 초대 링크 메시지를 공유하면, 초대 링크 메시지에 챌린저의 이름이 표시된다
  - 함께 하는 조력자가 있을 때, 챌린저는 home 페이지에서 조력자의 이름을 볼 수 있다
  - 함께 하는 조력자가 있을 때, 챌린저는 설정 페이지에서 조력자의 이름을 볼 수 있다
  - 함께 하는 챌린저가 있을 때, 조력자는 home 페이지에서 챌린저의 이름을 볼 수 있다

## 체크리스트

- [x] iOS에서 동작이 잘 되는지 확인 (제 로컬에서 iOS 시뮬레이터를 실행하면 에러가 발생해서 확인을 못했습니다 😢 )
- [x] 챌린저가 서포터 초대하기로 카카오톡 초대 링크 메시지를 공유하면, 초대 링크 메시지에 챌린저의 이름이 표시된다
- [x] 함께 하는 조력자가 있을 때, 챌린저는 home 페이지에서 조력자의 이름을 볼 수 있다
- [x] 함께 하는 조력자가 있을 때, 챌린저는 설정 페이지에서 조력자의 이름을 볼 수 있다
- [x] 함께 하는 챌린저가 있을 때, 조력자는 home 페이지에서 챌린저의 이름을 볼 수 있다

---

### TODO

- [ ] 초대코드 인증 완료 후 '000의 도전입니다'
  - input에 유효한 코드가 채워졌을 때 초록색 success가 나옴 -> 여기에 000의 미션입니다 같은 정보를 함께 보여주면 어떨까?
- [ ] FCM에서 알림 보낼때?
  - [ ] 000이 서포터로 등록되었습니다
  - [ ] 000이 서포터에서 해제되었습니다

## 스크린샷

> 함께 하는 조력자가 있을 때, 챌린저는 home 페이지에서 조력자의 이름을 볼 수 있다

<img width="444" alt="image" src="https://github.com/user-attachments/assets/9ec0e021-ea72-4a22-8735-23811a9097fd" />

> 챌린저가 서포터 초대하기로 카카오톡 초대 링크 메시지를 공유하면, 초대 링크 메시지에 챌린저의 이름이 표시된다

<img width="448" alt="image" src="https://github.com/user-attachments/assets/0d5968ad-8a89-4cc9-997f-dcab9def5774" />

> 함께 하는 조력자가 있을 때, 챌린저는 설정 페이지에서 조력자의 이름을 볼 수 있다

<img width="660" alt="image" src="https://github.com/user-attachments/assets/e00523ad-f997-4f3d-a135-bffe77733268" />

> 함께 하는 챌린저가 있을 때, 조력자는 home 페이지에서 챌린저의 이름을 볼 수 있다

<img width="309" alt="image" src="https://github.com/user-attachments/assets/3dc66c45-d020-45ad-8e9f-8c25f5919d2f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- 사용자 정보를 가져오는 새로운 인터페이스와 클래스가 추가되었습니다.
	- 사용자 이름을 설정하고 가져오는 기능이 추가되었습니다.
	- 홈 화면이 업데이트되어, 현재 참여자의 정보가 통합적으로 표시됩니다.
	- 지원자 화면에서 현재 참여자의 이름을 사용하여 공유 메시지를 생성합니다.
  
- **Bug Fixes**
	- 로그인 프로세스에서 오류 처리와 사용자 정보 가져오기가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->