### PR TITLE
[NY-148] 라우팅 단계에서 AuthGuard,RoleGuard 적용

### DIFF
--- a/lib/core/routes/guards/route_guard.dart
+++ b/lib/core/routes/guards/route_guard.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+abstract class RouteGuard {
+  /// 가드 활성화 여부를 확인하는 메서드
+  /// 통과 가능하면 null을 반환하고, 통과 불가능하면 이동할 경로를 반환
+  Future<String?> canActivate(
+      BuildContext? context, GoRouterState state, String? redirectPath);
+}
+
+class BaseGuard implements RouteGuard {
+  @override
+  Future<String?> canActivate(
+      BuildContext? context, GoRouterState state, String? redirectPath) async {
+    return null;
+  }
+}
+
+abstract class RouteGuardDecorator implements RouteGuard {
+  final RouteGuard _guard;
+
+  RouteGuardDecorator(this._guard);
+
+  @override
+  Future<String?> canActivate(
+      BuildContext? context, GoRouterState state, String? redirectPath) {
+    return _guard.canActivate(context, state, redirectPath);
+  }
+}
+
+RouteGuard applyGuards({
+  required List<RouteGuardDecorator Function(RouteGuard)> decorators,
+}) {
+  RouteGuard guard = BaseGuard();
+
+  for (final decorator in decorators) {
+    guard = decorator(guard);
+  }
+
+  return guard;
+}

--- a/lib/core/routes/route/go_route_with_guards.dart
+++ b/lib/core/routes/route/go_route_with_guards.dart
@@ -1,0 +1,18 @@
+import 'package:go_router/go_router.dart';
+import 'package:notiyou/core/routes/guards/route_guard.dart';
+
+class GoRouteWithGuards extends GoRoute {
+  final List<RouteGuard> guards;
+
+  GoRouteWithGuards({
+    required super.path,
+    super.name,
+    super.builder,
+    super.pageBuilder,
+    super.parentNavigatorKey,
+    super.redirect,
+    super.onExit,
+    super.routes = const <RouteBase>[],
+    required this.guards,
+  });
+}

--- a/lib/routes/guards/auth_guard.dart
+++ b/lib/routes/guards/auth_guard.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:notiyou/core/routes/guards/route_guard.dart';
+import 'package:notiyou/screens/login_page.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
+
+class AuthGuard extends RouteGuardDecorator {
+  AuthGuard(
+    super.guard,
+  );
+
+  @override
+  Future<String?> canActivate(
+      BuildContext? context, GoRouterState state, String? redirectPath) async {
+    final result = await super.canActivate(context, state, redirectPath);
+    if (result != null) {
+      return result;
+    }
+
+    final user = await AuthService.getUser();
+    if (user == null) {
+      return redirectPath ?? LoginPage.routeName;
+    }
+
+    return null;
+  }
+}

--- a/lib/routes/guards/role_guard.dart
+++ b/lib/routes/guards/role_guard.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:notiyou/core/routes/guards/route_guard.dart';
+import 'package:notiyou/models/registration_status.dart';
+import 'package:notiyou/screens/login_page.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
+
+class RoleGuard extends RouteGuardDecorator {
+  final List<UserRole> allowedRoles;
+
+  RoleGuard(super.guard, this.allowedRoles);
+
+  @override
+  Future<String?> canActivate(
+      BuildContext? context, GoRouterState state, String? redirectPath) async {
+    var result = await super.canActivate(context, state, redirectPath);
+    if (result != null) {
+      return result;
+    }
+
+    result = redirectPath ?? LoginPage.routeName;
+
+    final user = await AuthService.getUser();
+    if (user == null) {
+      return result;
+    }
+
+    final userRole = AuthService.getRegistrationStatus(user).registeredRole;
+    if (!allowedRoles.contains(userRole)) {
+      return result;
+    }
+
+    return null;
+  }
+}

--- a/lib/routes/index.dart
+++ b/lib/routes/index.dart
@@ -1,15 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:notiyou/core/routes/guards/route_guard.dart';
+import 'package:notiyou/core/routes/route/go_route_with_guards.dart';
 import 'package:notiyou/models/registration_status.dart';
-import 'package:notiyou/screens/supporter_config_page.dart';
-import 'package:notiyou/services/auth/auth_service.dart';
+import 'package:notiyou/routes/guards/auth_guard.dart';
+import 'package:notiyou/routes/guards/role_guard.dart';
+import 'package:notiyou/screens/challenger_config_page.dart';
+import 'package:notiyou/screens/history_page.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/screens/login_page.dart';
 import 'package:notiyou/screens/signup_page.dart';
-import 'package:notiyou/screens/challenger_config_page.dart';
-import 'package:notiyou/screens/history_page.dart';
 import 'package:notiyou/screens/splash_page.dart';
+import 'package:notiyou/screens/supporter_config_page.dart';
 import 'package:notiyou/screens/supporter_signup_page.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
 
 final routes = <RouteBase>[
   GoRoute(
@@ -22,21 +26,36 @@ final routes = <RouteBase>[
       initialChallengerCode: state.uri.queryParameters['challengerId'],
     ),
   ),
-  GoRoute(
+  GoRouteWithGuards(
     path: SignupPage.routeName,
     builder: (context, state) => const SignupPage(),
+    guards: [
+      applyGuards(decorators: [
+        (guard) => AuthGuard(guard),
+      ])
+    ],
   ),
-  GoRoute(
+  GoRouteWithGuards(
     path: SupporterSignupPage.routeName,
     builder: (context, state) => SupporterSignupPage(
       initialChallengerCode: state.uri.queryParameters['challengerId'],
     ),
+    guards: [
+      applyGuards(decorators: [
+        (guard) => AuthGuard(guard),
+      ])
+    ],
   ),
-  GoRoute(
+  GoRouteWithGuards(
     path: ChallengerConfigPage.onboardingRouteName,
     builder: (context, state) => const ChallengerConfigPage(
       isFirstTime: true,
     ),
+    guards: [
+      applyGuards(decorators: [
+        (guard) => AuthGuard(guard),
+      ])
+    ],
   ),
   ShellRoute(
     builder: (context, state, child) {
@@ -83,21 +102,45 @@ final routes = <RouteBase>[
 ];
 
 final List<GoRoute> bottomNavigationRoutes = [
-  GoRoute(
+  GoRouteWithGuards(
     path: HomePage.routeName,
     builder: (context, state) => const HomePage(),
+    guards: [
+      applyGuards(decorators: [
+        (guard) => AuthGuard(guard),
+        (guard) => RoleGuard(guard, [UserRole.challenger, UserRole.supporter]),
+      ])
+    ],
   ),
-  GoRoute(
+  GoRouteWithGuards(
     path: HistoryPage.routeName,
     builder: (context, state) => const HistoryPage(),
+    guards: [
+      applyGuards(decorators: [
+        (guard) => AuthGuard(guard),
+        (guard) => RoleGuard(guard, [UserRole.challenger, UserRole.supporter]),
+      ])
+    ],
   ),
-  GoRoute(
+  GoRouteWithGuards(
     path: ChallengerConfigPage.routeName,
     builder: (context, state) => const ChallengerConfigPage(),
+    guards: [
+      applyGuards(decorators: [
+        (guard) => AuthGuard(guard),
+        (guard) => RoleGuard(guard, [UserRole.challenger]),
+      ])
+    ],
   ),
-  GoRoute(
+  GoRouteWithGuards(
     path: SupporterConfigPage.routeName,
     builder: (context, state) => const SupporterConfigPage(),
+    guards: [
+      applyGuards(decorators: [
+        (guard) => AuthGuard(guard),
+        (guard) => RoleGuard(guard, [UserRole.supporter]),
+      ])
+    ],
   ),
 ];
 

--- a/lib/routes/router.dart
+++ b/lib/routes/router.dart
@@ -1,11 +1,12 @@
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:notiyou/core/routes/route/go_route_with_guards.dart';
 import 'package:notiyou/routes/index.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/screens/login_page.dart';
 import 'package:notiyou/screens/splash_page.dart';
 import 'package:notiyou/screens/supporter_signup_page.dart';
 import 'package:notiyou/services/invite_deep_link_service.dart';
-import 'package:flutter/foundation.dart';
 
 final routerRefreshNotifier = ValueNotifier<bool>(false);
 
@@ -21,10 +22,31 @@ final router = GoRouter(
       return routeName;
     }
 
+    final guardRedirectPath =
+        await _checkGuardRedirects(state.topRoute, context, state);
+    if (guardRedirectPath != null) {
+      return guardRedirectPath;
+    }
+
     return null;
   },
   routes: routes,
 );
+
+Future<String?> _checkGuardRedirects(
+    GoRoute? route, BuildContext context, GoRouterState state) async {
+  if (route is GoRouteWithGuards) {
+    final guards = route.guards;
+    for (final guard in guards) {
+      final canActivate = await guard.canActivate(context, state, null);
+      if (canActivate != null) {
+        return canActivate;
+      }
+    }
+  }
+
+  return null;
+}
 
 String? _getRouteFromInviteDeepLink(InviteDeepLinkInfo deepLink) {
   return switch (deepLink.userStatus) {

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -4,7 +4,6 @@ import 'package:notiyou/models/challenger_supporter_model.dart';
 import 'package:notiyou/models/mission.dart';
 import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/screens/challenger_config_page.dart';
-import 'package:notiyou/screens/signup_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:notiyou/services/challenger_config_service.dart';
 import 'package:notiyou/services/mission_history_service.dart';
@@ -33,12 +32,6 @@ class _HomePageState extends State<HomePage> {
     final user = await AuthService.getUserSafe();
 
     final userRole = AuthService.getRegistrationStatus(user).registeredRole;
-    if (userRole == UserRole.none) {
-      if (!mounted) return;
-      context.go(SignupPage.routeName);
-      return;
-    }
-
     final [missions, partner] = await Future.wait([
       _loadMissions(),
       _loadPartner(userRole),

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -3,7 +3,6 @@ import 'package:go_router/go_router.dart';
 import 'package:notiyou/entities/current_participant.dart';
 import 'package:notiyou/models/mission.dart';
 import 'package:notiyou/screens/challenger_config_page.dart';
-import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:notiyou/services/mission_history_service.dart';
 import 'package:notiyou/services/participant_service.dart';
 
@@ -28,8 +27,6 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _initPageView() async {
-    final user = await AuthService.getUserSafe();
-
     final [missions, participant] = await Future.wait([
       _loadMissions(),
       _participantService.getCurrentParticipant(),

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -1,4 +1,7 @@
+// ignore_for_file: invalid_visibility_annotation
+
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_talk.dart';
+import 'package:meta/meta.dart';
 import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/services/auth/kakao_auth_service.dart';
 import 'package:notiyou/services/auth/supabase_auth_service.dart';
@@ -13,6 +16,7 @@ class AuthException implements Exception {
 }
 
 // TODO: 자체 User 객체 생성 및 관리 필요.
+// TODO: 테스트 용이성을 위해 static class 제거 필요. 이를 위해선 어플리케이션 레이어에서 DI Container 사용 필요.
 class AuthService {
   static Future<supabase.User?> loginWithKakao() async {
     // * 기존 로그인 상태 초기화
@@ -48,7 +52,51 @@ class AuthService {
     return SupabaseAuthService.setRole(role);
   }
 
-  static Future<supabase.User?> getUser() async {
+  // TODO: static class 제거 이후 메서드 제거
+  @visibleForTesting
+  static dynamic _testUser;
+  // TODO: static class 제거 이후 메서드 제거
+  @visibleForTesting
+  static bool _alwaysReturnNull = false;
+  @visibleForTesting
+  static UserRole? _testRole;
+
+  // TODO: static class 제거 이후 메서드 제거
+  @visibleForTesting
+  static void setUserForTesting(dynamic user) {
+    _testUser = user;
+  }
+
+  @visibleForTesting
+  static void setRoleForTesting(UserRole role) {
+    _testRole = role;
+  }
+
+  // TODO: static class 제거 이후 메서드 제거
+  @visibleForTesting
+  static void setAlwaysReturnNullForTesting() {
+    _alwaysReturnNull = true;
+  }
+
+// TODO: static class 제거 이후 메서드 제거
+  @visibleForTesting
+  static void clearUserForTesting() {
+    _testUser = null;
+  }
+
+  static Future<dynamic> getUser() async {
+    // for testing
+    // TODO: static class 제거 이후 제거
+    if (_testUser != null) {
+      return _testUser;
+    }
+    // for testing
+    // TODO: static class 제거 이후 제거
+    if (_alwaysReturnNull) {
+      return null;
+    }
+
+    // 실제 구현 코드
     return await SupabaseAuthService.getUser();
   }
 
@@ -73,6 +121,12 @@ class AuthService {
   }
 
   static RegistrationStatus getRegistrationStatus(supabase.User user) {
+    // for testing
+    // TODO: static class 제거 이후 제거
+    if (_testRole != null) {
+      return RegistrationStatus(registeredRole: _testRole!);
+    }
+
     return SupabaseAuthService.getRegistrationStatus(user);
   }
 }

--- a/test/core/routes/guards/route_guard_test.dart
+++ b/test/core/routes/guards/route_guard_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:notiyou/core/routes/guards/route_guard.dart';
+
+class MockRouteGuard extends Mock implements RouteGuard {}
+
+class MockBuildContext extends Mock implements BuildContext {}
+
+class MockGoRouterState extends Mock implements GoRouterState {}
+
+void main() {
+  group('BaseGuard Interface 테스트', () {
+    test('BaseGuard는 항상 통과한다.', () async {
+      // arrange
+      final guard = BaseGuard();
+      final context = MockBuildContext();
+      final state = MockGoRouterState();
+      const redirectPath = '/redirect';
+
+      // act
+      final result = await guard.canActivate(context, state, redirectPath);
+
+      // assert
+      expect(result, isNull);
+    });
+  });
+
+  group('RouteGuardDecorator Interface 테스트', () {
+    test('데코레이터 생성시 전달받은 가드가 호출되어야 한다.', () async {
+      // arrange
+      final mockGuard = MockRouteGuard();
+      final decorator = RouteGuardDecoratorImpl(mockGuard);
+      final context = MockBuildContext();
+      final state = MockGoRouterState();
+      const redirectPath = '/redirect';
+
+      when(() => mockGuard.canActivate(context, state, redirectPath))
+          .thenAnswer((_) async => redirectPath);
+
+      // act
+      final result = await decorator.canActivate(context, state, redirectPath);
+
+      // assert
+      expect(result, equals(redirectPath));
+      verify(() => mockGuard.canActivate(context, state, redirectPath))
+          .called(1);
+    });
+  });
+}
+
+class RouteGuardDecoratorImpl extends RouteGuardDecorator {
+  RouteGuardDecoratorImpl(super.guard);
+
+  @override
+  Future<String?> canActivate(
+      BuildContext? context, GoRouterState state, String? redirectPath) async {
+    final result = await super.canActivate(context, state, redirectPath);
+    if (result != null) {
+      return result;
+    }
+    return null;
+  }
+}

--- a/test/core/routes/route/go_route_with_guards_test.dart
+++ b/test/core/routes/route/go_route_with_guards_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:notiyou/core/routes/guards/route_guard.dart';
+import 'package:notiyou/core/routes/route/go_route_with_guards.dart';
+
+class MockWidget extends Mock implements Widget {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return super.toString();
+  }
+}
+
+class MockRouteGuard extends Mock implements RouteGuard {}
+
+void main() {
+  group('GoRouteWithGuards', () {
+    late List<RouteGuard> guards;
+    late MockWidget mockWidget;
+
+    setUp(() {
+      guards = [MockRouteGuard(), MockRouteGuard()];
+      mockWidget = MockWidget();
+    });
+
+    test('생성자가 올바르게 동작해야 함', () {
+      const path = '/test';
+      const name = 'test';
+
+      final route = GoRouteWithGuards(
+        path: path,
+        name: name,
+        guards: guards,
+        builder: (context, state) => mockWidget,
+      );
+
+      expect(route.path, path);
+      expect(route.name, name);
+      expect(route.guards, guards);
+      expect(route.guards.length, 2);
+    });
+
+    test('guards 목록이 비어 있어도 작동해야 함', () {
+      final route = GoRouteWithGuards(
+        path: '/no-guards',
+        guards: const [],
+        builder: (context, state) => mockWidget,
+      );
+
+      expect(route.guards, isEmpty);
+    });
+  });
+}

--- a/test/routes/guards/auth_guard_test.dart
+++ b/test/routes/guards/auth_guard_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:notiyou/core/routes/guards/route_guard.dart';
+import 'package:notiyou/routes/guards/auth_guard.dart';
+import 'package:notiyou/screens/login_page.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
+
+class MockRouteGuard extends Mock implements RouteGuard {}
+
+class MockBuildContext extends Mock implements BuildContext {}
+
+class MockGoRouterState extends Mock implements GoRouterState {}
+
+class MockUser extends Mock {}
+
+void main() {
+  late MockRouteGuard mockGuard;
+  late AuthGuard authGuard;
+  late MockBuildContext context;
+  late MockGoRouterState state;
+  const redirectPath = '/redirect';
+
+  setUpAll(() {
+    registerFallbackValue(MockBuildContext());
+    registerFallbackValue(MockGoRouterState());
+  });
+
+  setUp(() {
+    mockGuard = MockRouteGuard();
+    authGuard = AuthGuard(mockGuard);
+    context = MockBuildContext();
+    state = MockGoRouterState();
+  });
+
+  group('AuthGuard', () {
+    test('인증된 사용자가 있으면 접근을 허용해야 한다', () async {
+      // arrange
+      when(() => mockGuard.canActivate(any(), any(), any()))
+          .thenAnswer((_) async => null);
+
+      AuthService.setUserForTesting(MockUser());
+
+      // act
+      final result = await authGuard.canActivate(context, state, redirectPath);
+
+      // assert
+      expect(result, isNull);
+      verify(() => mockGuard.canActivate(context, state, redirectPath))
+          .called(1);
+
+      AuthService.clearUserForTesting();
+    });
+
+    test('인증된 사용자가 없으면 redirectPath로 리디렉션해야 한다', () async {
+      // arrange
+      when(() => mockGuard.canActivate(any(), any(), any()))
+          .thenAnswer((_) async => null);
+
+      AuthService.setAlwaysReturnNullForTesting();
+
+      // act
+      final result = await authGuard.canActivate(context, state, redirectPath);
+
+      // assert
+      expect(result, equals(redirectPath));
+      verify(() => mockGuard.canActivate(context, state, redirectPath))
+          .called(1);
+    });
+
+    test('redirectPath가 null이면 LoginPage.routeName으로 리디렉션해야 한다', () async {
+      // arrange
+      when(() => mockGuard.canActivate(any(), any(), null))
+          .thenAnswer((_) async => null);
+
+      AuthService.setAlwaysReturnNullForTesting();
+
+      // act
+      final result = await authGuard.canActivate(context, state, null);
+
+      // assert
+      expect(result, equals(LoginPage.routeName));
+      verify(() => mockGuard.canActivate(context, state, null)).called(1);
+    });
+
+    test('부모 가드가 리디렉션을 반환하면 그 값을 그대로 반환해야 한다', () async {
+      // arrange
+      when(() => mockGuard.canActivate(any(), any(), any()))
+          .thenAnswer((_) async => '/other-route');
+
+      // act
+      final result = await authGuard.canActivate(context, state, redirectPath);
+
+      // assert
+      expect(result, equals('/other-route'));
+      verify(() => mockGuard.canActivate(context, state, redirectPath))
+          .called(1);
+    });
+  });
+}

--- a/test/routes/guards/role_guard_test.dart
+++ b/test/routes/guards/role_guard_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:notiyou/core/routes/guards/route_guard.dart';
+import 'package:notiyou/models/registration_status.dart';
+import 'package:notiyou/routes/guards/role_guard.dart';
+import 'package:notiyou/screens/login_page.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+class MockRouteGuard extends Mock implements RouteGuard {}
+
+class MockBuildContext extends Mock implements BuildContext {}
+
+class MockGoRouterState extends Mock implements GoRouterState {}
+
+class MockUser extends Mock implements supabase.User {}
+
+void main() {
+  late MockRouteGuard mockGuard;
+  late RoleGuard roleGuard;
+  late MockBuildContext context;
+  late MockGoRouterState state;
+  late MockUser mockUser;
+  const redirectPath = '/redirect';
+
+  setUpAll(() {
+    registerFallbackValue(MockBuildContext());
+    registerFallbackValue(MockGoRouterState());
+  });
+
+  setUp(() {
+    mockGuard = MockRouteGuard();
+    roleGuard = RoleGuard(mockGuard, [UserRole.challenger]);
+    context = MockBuildContext();
+    state = MockGoRouterState();
+    mockUser = MockUser();
+  });
+
+  group('RoleGuard', () {
+    test('허용된 역할을 가진 사용자는 접근을 허용해야 한다', () async {
+      // arrange
+      when(() => mockGuard.canActivate(any(), any(), any()))
+          .thenAnswer((_) async => null);
+
+      AuthService.setUserForTesting(mockUser);
+      AuthService.setRoleForTesting(UserRole.challenger);
+
+      // act
+      final result = await roleGuard.canActivate(context, state, redirectPath);
+
+      // assert
+      expect(result, isNull);
+      verify(() => mockGuard.canActivate(context, state, redirectPath))
+          .called(1);
+
+      AuthService.clearUserForTesting();
+    });
+
+    test('허용되지 않은 역할을 가진 사용자는 redirectPath로 리디렉션해야 한다', () async {
+      // arrange
+      when(() => mockGuard.canActivate(any(), any(), any()))
+          .thenAnswer((_) async => null);
+
+      AuthService.setUserForTesting(mockUser);
+      AuthService.setRoleForTesting(UserRole.supporter);
+
+      // act
+      final result = await roleGuard.canActivate(context, state, redirectPath);
+
+      // assert
+      expect(result, equals(redirectPath));
+      verify(() => mockGuard.canActivate(context, state, redirectPath))
+          .called(1);
+
+      AuthService.clearUserForTesting();
+    });
+
+    test('redirectPath가 null이면 LoginPage.routeName으로 리디렉션해야 한다', () async {
+      // arrange
+      when(() => mockGuard.canActivate(any(), any(), null))
+          .thenAnswer((_) async => null);
+
+      AuthService.setUserForTesting(mockUser);
+      AuthService.setRoleForTesting(UserRole.supporter);
+
+      // act
+      final result = await roleGuard.canActivate(context, state, null);
+
+      // assert
+      expect(result, equals(LoginPage.routeName));
+      verify(() => mockGuard.canActivate(context, state, null)).called(1);
+
+      AuthService.clearUserForTesting();
+    });
+
+    test('부모 가드가 리디렉션을 반환하면 그 값을 그대로 반환해야 한다', () async {
+      // arrange
+      when(() => mockGuard.canActivate(any(), any(), any()))
+          .thenAnswer((_) async => '/other-route');
+
+      // act
+      final result = await roleGuard.canActivate(context, state, redirectPath);
+
+      // assert
+      expect(result, equals('/other-route'));
+      verify(() => mockGuard.canActivate(context, state, redirectPath))
+          .called(1);
+    });
+
+    test('사용자가 없는 경우 redirectPath로 리디렉션해야 한다', () async {
+      // arrange
+      when(() => mockGuard.canActivate(any(), any(), any()))
+          .thenAnswer((_) async => null);
+
+      AuthService.setAlwaysReturnNullForTesting();
+
+      // act
+      final result = await roleGuard.canActivate(context, state, redirectPath);
+
+      // assert
+      expect(result, equals(redirectPath));
+      verify(() => mockGuard.canActivate(context, state, redirectPath))
+          .called(1);
+    });
+  });
+}


### PR DESCRIPTION
## 요약

- 앱에서 라우팅이 일어날때, 사용자 인증 또는 역할에 따른 Guard 동작이 이루어지도록 개발하였습니다.

## 작업 내용

- [feat: RouteGuard, GoRouteWithGuards 구현](https://github.com/buku-buku/notiyou/pull/84/commits/1ecc9c784f7c4c2f8c848ece1f961cc32880a25e)
- [text: authGuard, roleGuard 테스트 코드 작성](https://github.com/buku-buku/notiyou/pull/84/commits/73da174257f2d2466233073654521106da0520be)
- [feat: authGuard, roleGuard 구현](https://github.com/buku-buku/notiyou/pull/84/commits/19c1d82f90f557d9e51b0d246ef5edf80373a47b)
- [feat: 기존 router에 authGuard, roleGuard 적용](https://github.com/buku-buku/notiyou/pull/84/commits/42bdc6a10fcd0dcd737b9af8e0e10745728aaded)
- [refactor: homePage에서의 불필요한 role 검증 제거](https://github.com/buku-buku/notiyou/pull/84/commits/3af4d5ee0037b9afd42e120f99dd9a30271313ac)


## 테스트

<img width="714" alt="image" src="https://github.com/user-attachments/assets/254bd142-1db2-4fca-ab66-f245f9f9e746" />

<img width="679" alt="image" src="https://github.com/user-attachments/assets/54d715f9-0f52-405b-8ea2-241eeedd3206" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - 앱 내 주요 페이지 접근 시 사용자 인증 및 역할 기반 제어가 강화되었습니다.
- **Refactor**
  - 내비게이션 로직이 개선되어, 보호 기능이 통합된 경로 제어 방식으로 업데이트되었습니다.
  - 홈 화면에서 불필요한 회원가입 리디렉션 로직이 제거되었습니다.
- **Tests**
  - 추가된 라우팅 보호 기능을 대상으로 한 테스트 케이스가 도입되어 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->