### PR TITLE
[NY-155] 무호님과 Pair QA에서 나온 간단한 이슈 해결

### DIFF
--- a/lib/repositories/mission_history_repository/mission_history_repository_remote.dart
+++ b/lib/repositories/mission_history_repository/mission_history_repository_remote.dart
@@ -179,7 +179,7 @@ class MissionHistoryRepositoryRemote implements MissionHistoryRepository {
         .map((e) => Mission.fromMissionHistoryEntity(e))
         .toList();
 
-    missions.sort((a, b) => a.id.compareTo(b.id));
+    missions.sort((a, b) => b.date.compareTo(a.date));
 
     return missions;
   }

--- a/lib/screens/history_page.dart
+++ b/lib/screens/history_page.dart
@@ -36,7 +36,7 @@ class _HistoryPageState extends State<HistoryPage> {
     for (var mission in missions) {
       final dateKey = TimeUtils.formatDateTime(
         date: mission.date,
-        format: 'yyyy-MM-dd (E)',
+        format: 'yyyy.MM.dd (E)',
       );
 
       if (groupedMissions.containsKey(dateKey)) {

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -59,9 +59,22 @@ class LoginPage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Login')),
       body: Center(
-        child: ElevatedButton(
-          onPressed: () => _handleKakaoLogin(context),
-          child: const Text('카카오톡으로 시작하기'),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: () => _handleKakaoLogin(context),
+              child: const Text('카카오톡으로 시작하기'),
+            ),
+            const SizedBox(height: 8), // 버튼과 텍스트 사이 간격
+            const Text(
+              '카카오톡 프로필에 설정된 이름으로 가입됩니다',
+              style: TextStyle(
+                fontSize: 12,
+                color: Colors.grey,
+              ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## 요약

- 히스토리 페이지 정렬이 이상한 문제를 해결합니다
- 히스토리 페이지에서 보여주는 날짜 포맷을 변경합니다.
- 회원가입시 카톡 프로필 이름을 사용한다는 문구 추가합니다.


## 작업 내용

<!-- slot-start -->

- [fix: 히스토리 페이지에서 미션 히스토리 목록을 최신 날짜 기준 정렬](https://github.com/buku-buku/notiyou/pull/86/commits/f9f0e6abeda36a17ef870386adcc5d4520974f82)
- [style: 날짜 포맷을 YYYY.mm.dd로 변경](https://github.com/buku-buku/notiyou/pull/86/commits/3295f7d4f1cd85e2b5559aaa4fe6ae8176d647d3)
- [feat: (NY-147) 회원가입시 카톡 프로필 이름을 사용한다는 문구 추가](https://github.com/buku-buku/notiyou/pull/86/commits/cf2cba3a085e83520d40f8e32fb3ec1735863f0c)

<!-- slot-end -->


## 스크린샷

<img width="596" alt="image" src="https://github.com/user-attachments/assets/dd3d84f1-89a8-4e05-a578-5eb39bd534eb" />

<img width="596" alt="image" src="https://github.com/user-attachments/assets/a5edf525-bf58-4dff-894d-32437c921e2b" />

