### PR TITLE
[NY-171] 조력자 해제 컨펌시 스낵바가 노출되지 않음

### DIFF
--- a/lib/screens/supporter_config_page.dart
+++ b/lib/screens/supporter_config_page.dart
@@ -65,9 +65,14 @@ class SupporterConfigPage extends StatelessWidget {
 
                 if (confirm == true) {
                   await ChallengerConfigService.quitSupporter();
-                  if (context.mounted) {
-                    context.go(SignupPage.routeName);
-                  }
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('서포터를 그만두었습니다.'),
+                      duration: Duration(seconds: 2),
+                    ),
+                  );
+                  context.go(SignupPage.routeName);
                 }
               },
               child: const Text(


### PR DESCRIPTION
## 요약
- [[QA FAiled] 조력자 해제 컨펌시 스낵바가 노출되지 않음](https://www.notion.so/QA-FAiled-1c81a561484480ffa37fd26864f202bb?pvs=4)에 대한 처리입니다.
  - 서포터가 '서포터 그만두기' 버튼 클릭 후, 팝업 창을 confirm 했을 때 초기화면으로 라우팅되면서 하단에 snack bar로 '서포터를 그만두었스빈다'를 띄워줍니다.

## 스크린샷

https://github.com/user-attachments/assets/aadb83cc-8df1-4ad9-8144-6437af56e836




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 후원자 탈퇴 시, 사용자에게 2초 동안 표시되는 알림 메시지가 추가되어 탈퇴 완료 후 즉각적인 피드백을 제공합니다.
  - 알림 메시지 표시가 끝나면 자동으로 가입 페이지로 이동하는 기능이 적용되어 사용자 흐름이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->