### PR TITLE
[NY-150] 조력자가 초대 코드로 인증을 완료하면, 챌린저 이름으로 ‘OOO의 도전입니다’이 표시된다

### DIFF
--- a/lib/exceptions/repository_exception.dart
+++ b/lib/exceptions/repository_exception.dart
@@ -1,0 +1,10 @@
+class RepositoryException implements Exception {
+  final String message;
+  final String? details;
+
+  const RepositoryException(this.message, {this.details});
+}
+
+class EntityNotFoundException extends RepositoryException {
+  const EntityNotFoundException(super.message, {super.details});
+}

--- a/lib/repositories/participant_repository/participant_repository_remote.dart
+++ b/lib/repositories/participant_repository/participant_repository_remote.dart
@@ -1,12 +1,18 @@
 import 'package:notiyou/entities/current_participant.dart';
+import 'package:notiyou/exceptions/repository_exception.dart';
 import 'package:notiyou/repositories/participant_repository/participant_repository_interface.dart';
 import 'package:notiyou/repositories/supabase_table_names_constants.dart';
+import 'package:notiyou/repositories/user_metadata_repository/user_metadata_repository_interface.dart';
+import 'package:notiyou/repositories/user_metadata_repository/user_metadata_repository_remote.dart';
 import 'package:notiyou/services/supabase_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class ParticipantRepositoryRemote implements ParticipantRepository {
   static final ParticipantRepositoryRemote _instance =
       ParticipantRepositoryRemote._internal();
+
+  final UserMetadataRepository _userMetadataRepository =
+      UserMetadataRepositoryRemote();
 
   ParticipantRepositoryRemote._internal();
 
@@ -28,52 +34,53 @@ class ParticipantRepositoryRemote implements ParticipantRepository {
 
   @override
   Future<CurrentParticipant> getParticipantById(String userId) async {
-    final currentUserMetadata = await supabaseClient
-        .from(SupabaseTableNames.userMetadata)
-        .select()
-        .eq('id', userId)
-        .single();
+    try {
+      final currentUserMetadata =
+          await _userMetadataRepository.getUserMetadataByUserId(userId);
 
-    final challengerSupporter = await supabaseClient
-        .from(SupabaseTableNames.challengerSupporter)
-        .select('challenger_id, supporter_id')
-        .or('challenger_id.eq.$userId,supporter_id.eq.$userId')
-        .maybeSingle();
+      final challengerSupporter = await supabaseClient
+          .from(SupabaseTableNames.challengerSupporter)
+          .select('challenger_id, supporter_id')
+          .or('challenger_id.eq.$userId,supporter_id.eq.$userId')
+          .maybeSingle();
 
-    final hasChallengerSupporter = challengerSupporter != null;
-    final isUserChallenger = hasChallengerSupporter &&
-        userId == challengerSupporter['challenger_id'];
+      final hasChallengerSupporter = challengerSupporter != null;
+      final isUserChallenger = hasChallengerSupporter &&
+          userId == challengerSupporter['challenger_id'];
 
-    String? partnerId;
-    if (hasChallengerSupporter) {
-      partnerId = isUserChallenger
-          ? challengerSupporter['supporter_id']
-          : challengerSupporter['challenger_id'];
-    }
+      String? partnerId;
+      if (hasChallengerSupporter) {
+        partnerId = isUserChallenger
+            ? challengerSupporter['supporter_id']
+            : challengerSupporter['challenger_id'];
+      }
 
-    Partner? partner;
-    final hasPartner = partnerId != null;
-    if (hasPartner) {
-      final partnerMetadata = await supabaseClient
-          .from(SupabaseTableNames.userMetadata)
-          .select()
-          .eq('id', partnerId)
-          .single();
+      Partner? partner;
+      final hasPartner = partnerId != null;
+      if (hasPartner) {
+        final partnerMetadata =
+            await _userMetadataRepository.getUserMetadataByUserId(partnerId);
 
-      partner = Partner(
+        partner = Partner(
+          type: isUserChallenger
+              ? ParticipantType.supporter
+              : ParticipantType.challenger,
+          name: partnerMetadata['name'],
+        );
+      }
+
+      return CurrentParticipant(
+        name: currentUserMetadata['name'],
         type: isUserChallenger
-            ? ParticipantType.supporter
-            : ParticipantType.challenger,
-        name: partnerMetadata['name'],
+            ? ParticipantType.challenger
+            : ParticipantType.supporter,
+        partner: partner,
+      );
+    } catch (e) {
+      throw RepositoryException(
+        'Failed to execute getParticipantById',
+        details: e.toString(),
       );
     }
-
-    return CurrentParticipant(
-      name: currentUserMetadata['name'],
-      type: isUserChallenger
-          ? ParticipantType.challenger
-          : ParticipantType.supporter,
-      partner: partner,
-    );
   }
 }

--- a/lib/repositories/user_metadata_repository/user_metadata_repository_interface.dart
+++ b/lib/repositories/user_metadata_repository/user_metadata_repository_interface.dart
@@ -3,4 +3,5 @@ abstract class UserMetadataRepository {
   Future<String?> getFCMToken();
   Future<void> setName(String name);
   Future<String?> getName();
+  Future<Map<String, dynamic>> getUserMetadataByUserId(String userId);
 }

--- a/lib/repositories/user_metadata_repository/user_metadata_repository_remote.dart
+++ b/lib/repositories/user_metadata_repository/user_metadata_repository_remote.dart
@@ -1,3 +1,4 @@
+import 'package:notiyou/exceptions/repository_exception.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:notiyou/repositories/supabase_table_names_constants.dart';
 import 'package:notiyou/repositories/user_metadata_repository/user_metadata_repository_interface.dart';
@@ -100,5 +101,28 @@ class UserMetadataRepositoryRemote implements UserMetadataRepository {
 
     final data = userMetadata.first;
     return data['name'];
+  }
+
+  @override
+  Future<Map<String, dynamic>> getUserMetadataByUserId(String userId) async {
+    final userMetadata = await supabaseClient
+        .from(SupabaseTableNames.userMetadata)
+        .select()
+        .eq('id', userId);
+
+    if (userMetadata.isEmpty) {
+      throw EntityNotFoundException(
+        'User not found',
+        details: 'No user found with ID: $userId',
+      );
+    }
+
+    if (userMetadata.length > 1) {
+      throw RepositoryException(
+        'Multiple user metadata found for user ID: $userId',
+      );
+    }
+
+    return userMetadata.first;
   }
 }

--- a/lib/services/challenger_code/challenger_code_service.dart
+++ b/lib/services/challenger_code/challenger_code_service.dart
@@ -74,7 +74,7 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
   }
 
   @override
-  Future<void> verifyCode(String code) async {
+  Future<String> verifyCode(String code) async {
     if (code.isEmpty) {
       throw const ChallengerCodeException(
         message: '도전자 코드를 입력해주세요',
@@ -82,7 +82,8 @@ class ChallengerCodeServiceImpl implements ChallengerCodeService {
       );
     }
     try {
-      await extractUserId(code);
+      final userId = await extractUserId(code);
+      return userId;
     } catch (e) {
       throw ChallengerCodeException(
         message: '도전자 코드 검증에 실패했습니다',

--- a/lib/services/challenger_code/challenger_code_service_interface.dart
+++ b/lib/services/challenger_code/challenger_code_service_interface.dart
@@ -1,5 +1,5 @@
 abstract interface class ChallengerCodeService {
   Future<String> generateCode(String userId);
-  Future<void> verifyCode(String code);
+  Future<String> verifyCode(String code);
   Future<String> extractUserId(String code);
 }


### PR DESCRIPTION
## 요약

조력자가 초대 코드로 인증을 완료하면, 챌린저 이름으로 ‘OOO의 도전입니다’이 표시된다

## 작업 내용

<!-- slot-start -->

- [feat: userMetadata 가져오기 위한 메서드 및 에러 타입 추가](https://github.com/buku-buku/notiyou/pull/91/commits/5ba611c7dd98a6e50b90c94419f3c12822e95599)
- [feat: ParticipantRepositoryRemote에서 올바르지 않은 userId 예외 처리 추가](https://github.com/buku-buku/notiyou/pull/91/commits/1fca1a749b88ec452f557167e4bb8c90513c77e1)
- [feat: 조력자 회원가입 페이지에서 도전자 코드가 검증되면 프로필 안내](https://github.com/buku-buku/notiyou/pull/91/commits/95dab0523caf65ee087dd945cf99b74a282a7859)

<!-- slot-end -->


## 스크린샷


https://github.com/user-attachments/assets/c3fe6add-68f7-4976-ad00-ab1c1522dae7




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 회원가입 페이지에서 초대 코드 검증 후 성공 메시지가 표시되어 사용자 경험이 개선되었습니다.
  - 코드 검증 서비스가 이제 사용자 ID를 반환하여 보다 명확한 피드백을 제공합니다.

- **Refactor**
  - 참가자 정보 조회 과정과 사용자 메타데이터 처리 로직이 최적화되어 오류 상황에 대한 대응이 강화되었습니다.
  - 신규 예외 처리 구조 도입으로 문제 발생 시 명확한 안내가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->