### PR TITLE
[FIX] Testflight에서 FCM 알림을 받기 위한 빌드 설정 변경

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>aps-environment</key>
-	<string>development</string>
+	<string>production</string>
 </dict>
 </plist>


### PR DESCRIPTION
## 요약
- `APS Environment`를 development에서 production 으로 변경 (APNs 키를 sandbox 용에서 sandbox + production 용으로 재발급 후 FCM에 등록했음)
- `FirebaseAppDelegateProxyEnabled` false 추가
- [트러블슈팅 ISSUE 등록](https://github.com/buku-buku/notiyou/issues/93)

## 작업 내용
- [APS Environment](https://developer.apple.com/documentation/bundleresources/entitlements/aps-environment)
  - testflight는 프로덕션으로 취급되는 것일까?
- [FirebaseAppDelegateProxyEnabled](https://firebase.google.com/docs/cloud-messaging/ios/client?hl=ko#method_swizzling_in)
  - 기본적으로 firebase sdk는 푸시알람을 개발자의 코드가 아니라 자체적으로 제어하려는 것 같음. 이를 방지하기 위해서는 false 옵션을 설정해야한다..는 느낌적인 느낌인데 공식적인 설명은 못 찾음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

이번 업데이트에서는 앱의 외부 서비스 연동과 알림 전달 시스템 구성이 개선되었습니다.

- **Chores**
  - Firebase 통합 설정을 업데이트하여 서비스 연동의 안정성을 강화하였습니다.
  - 푸시 알림 환경을 개발 모드에서 프로덕션 모드로 전환하여 실시간 알림 전달이 보다 안정적으로 이루어지도록 하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->