### PR TITLE
[NY-172] 조력자 role이 변경되지 않는 문제 / Supabase Authentication의 메타데이터를 별도 테이블에서 직접 관리

### DIFF
--- a/lib/repositories/user_metadata_repository/user_metadata_repository_interface.dart
+++ b/lib/repositories/user_metadata_repository/user_metadata_repository_interface.dart
@@ -1,7 +1,11 @@
+import 'package:notiyou/models/registration_status.dart';
+
 abstract class UserMetadataRepository {
   Future<void> setFCMToken(String token);
   Future<String?> getFCMToken();
   Future<void> setName(String name);
   Future<String?> getName();
   Future<Map<String, dynamic>> getUserMetadataByUserId(String userId);
+  Future<UserRole> getRole(String userId);
+  Future<void> updateRole(String userId, UserRole role);
 }

--- a/lib/repositories/user_metadata_repository/user_metadata_repository_remote.dart
+++ b/lib/repositories/user_metadata_repository/user_metadata_repository_remote.dart
@@ -1,4 +1,5 @@
 import 'package:notiyou/exceptions/repository_exception.dart';
+import 'package:notiyou/models/registration_status.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:notiyou/repositories/supabase_table_names_constants.dart';
 import 'package:notiyou/repositories/user_metadata_repository/user_metadata_repository_interface.dart';
@@ -124,5 +125,23 @@ class UserMetadataRepositoryRemote implements UserMetadataRepository {
     }
 
     return userMetadata.first;
+  }
+
+  @override
+  Future<UserRole> getRole(String userId) async {
+    final result = await supabaseClient
+        .from(SupabaseTableNames.userMetadata)
+        .select('role')
+        .eq('id', userId)
+        .single();
+
+    return UserRole.fromString(result['role']);
+  }
+
+  @override
+  Future<void> updateRole(String userId, UserRole role) async {
+    await supabaseClient.from(SupabaseTableNames.userMetadata).update({
+      'role': role.name,
+    }).eq('id', userId);
   }
 }

--- a/lib/routes/guards/role_guard.dart
+++ b/lib/routes/guards/role_guard.dart
@@ -4,6 +4,7 @@ import 'package:notiyou/core/routes/guards/route_guard.dart';
 import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/screens/login_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
+import 'package:notiyou/services/user_metadata_service.dart';
 
 class RoleGuard extends RouteGuardDecorator {
   final List<UserRole> allowedRoles;
@@ -25,7 +26,7 @@ class RoleGuard extends RouteGuardDecorator {
       return result;
     }
 
-    final userRole = AuthService.getRegistrationStatus(user).registeredRole;
+    final userRole = await UserMetadataService.getRole(user.id);
     if (!allowedRoles.contains(userRole)) {
       return result;
     }

--- a/lib/routes/index.dart
+++ b/lib/routes/index.dart
@@ -14,6 +14,7 @@ import 'package:notiyou/screens/splash_page.dart';
 import 'package:notiyou/screens/supporter_config_page.dart';
 import 'package:notiyou/screens/supporter_signup_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
+import 'package:notiyou/services/user_metadata_service.dart';
 
 final routes = <RouteBase>[
   GoRoute(
@@ -81,8 +82,7 @@ final routes = <RouteBase>[
               }
             } else if (index == 2) {
               final user = await AuthService.getUserSafe();
-              final userRole =
-                  AuthService.getRegistrationStatus(user).registeredRole;
+              final userRole = await UserMetadataService.getRole(user.id);
               if (context.mounted) {
                 if (userRole == UserRole.challenger) {
                   context.go(ChallengerConfigPage.routeName);

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -4,6 +4,7 @@ import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:notiyou/services/mission_config_service.dart';
+import 'package:notiyou/services/user_metadata_service.dart';
 import 'package:notiyou/widgets/notification_template_config.dart';
 import 'package:notiyou/widgets/supporter_section.dart';
 
@@ -139,7 +140,8 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
       setState(() => _isSubmitLoading = true);
       await _saveTimes();
       if (widget.isFirstTime) {
-        AuthService.setRole(UserRole.challenger);
+        final userId = await AuthService.getUserId();
+        await UserMetadataService.setRole(userId, UserRole.challenger);
       }
       if (mounted) {
         context.go(HomePage.routeName);

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -6,6 +6,7 @@ import 'package:notiyou/screens/supporter_signup_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
 
 import 'package:notiyou/screens/signup_page.dart';
+import 'package:notiyou/services/user_metadata_service.dart';
 
 class LoginPage extends StatelessWidget {
   static const routeName = '/login';
@@ -23,17 +24,17 @@ class LoginPage extends StatelessWidget {
         throw Exception('User not found');
       }
 
-      final registrationStatus = AuthService.getRegistrationStatus(user);
+      final userRole = await UserMetadataService.getRole(user.id);
       if (!context.mounted) {
         return;
       }
 
-      if (registrationStatus.registeredRole != UserRole.none) {
+      if (userRole != UserRole.none) {
         context.go(HomePage.routeName);
         return;
       }
 
-      if (registrationStatus.registeredRole == UserRole.none) {
+      if (userRole == UserRole.none) {
         if (initialChallengerCode != null) {
           context.go(SupporterSignupPage.routeName,
               extra: initialChallengerCode);

--- a/lib/screens/splash_page.dart
+++ b/lib/screens/splash_page.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:notiyou/screens/home_page.dart';
 import 'package:notiyou/screens/login_page.dart';
 import 'package:notiyou/screens/signup_page.dart';
-import 'package:notiyou/services/auth/auth_service.dart';
+import 'package:notiyou/services/user_metadata_service.dart';
 
 class SplashPage extends StatefulWidget {
   const SplashPage({super.key});
@@ -24,14 +24,13 @@ class _SplashPageState extends State<SplashPage> {
 
   Future<void> _checkLoginStatus() async {
     try {
-      final user = await AuthService.getUserSafe();
-
-      final isRegistrationComplete = AuthService.isRegistrationCompleted(user);
+      final isRoleRegistered =
+          await UserMetadataService.isRoleRegistrationCompleted();
       if (!mounted) {
         return;
       }
 
-      if (isRegistrationComplete) {
+      if (isRoleRegistered) {
         context.go(HomePage.routeName);
       } else {
         context.go(SignupPage.routeName);

--- a/lib/screens/supporter_signup_page.dart
+++ b/lib/screens/supporter_signup_page.dart
@@ -13,6 +13,7 @@ import 'package:notiyou/services/challenger_code/challenger_code_service_interfa
 import 'package:notiyou/services/challenger_config_service.dart';
 import 'package:notiyou/exceptions/challenger_supporter_exception.dart';
 import 'package:notiyou/services/participant_service.dart';
+import 'package:notiyou/services/user_metadata_service.dart';
 
 class SupporterSignupPage extends StatefulWidget {
   const SupporterSignupPage({
@@ -115,9 +116,10 @@ class _SupporterSignupPageState extends State<SupporterSignupPage> {
   }
 
   Future<void> _registerMissionSupporter(String code) async {
+    final userId = await AuthService.getUserId();
     final challengerId = await _challengerCodeService.extractUserId(code);
     await ChallengerConfigService.registerSupporter(challengerId);
-    await AuthService.setRole(UserRole.supporter);
+    await UserMetadataService.setRole(userId, UserRole.supporter);
   }
 
   void _onNextPressed() async {

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -2,7 +2,6 @@
 
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_talk.dart';
 import 'package:meta/meta.dart';
-import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/repositories/user_metadata_repository/user_metadata_repository_remote.dart';
 import 'package:notiyou/services/auth/kakao_auth_service.dart';
 import 'package:notiyou/services/auth/supabase_auth_service.dart';
@@ -71,18 +70,11 @@ class AuthService {
   // TODO: static class 제거 이후 메서드 제거
   @visibleForTesting
   static bool _alwaysReturnNull = false;
-  @visibleForTesting
-  static UserRole? _testRole;
 
   // TODO: static class 제거 이후 메서드 제거
   @visibleForTesting
   static void setUserForTesting(dynamic user) {
     _testUser = user;
-  }
-
-  @visibleForTesting
-  static void setRoleForTesting(UserRole role) {
-    _testRole = role;
   }
 
   // TODO: static class 제거 이후 메서드 제거

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -6,7 +6,6 @@ import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/repositories/user_metadata_repository/user_metadata_repository_remote.dart';
 import 'package:notiyou/services/auth/kakao_auth_service.dart';
 import 'package:notiyou/services/auth/supabase_auth_service.dart';
-import 'package:notiyou/services/user_metadata_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
 class AuthException implements Exception {
@@ -64,10 +63,6 @@ class AuthService {
     } catch (e) {
       return false;
     }
-  }
-
-  static Future<void> setRole(UserRole role) async {
-    return SupabaseAuthService.setRole(role);
   }
 
   // TODO: static class 제거 이후 메서드 제거
@@ -132,9 +127,5 @@ class AuthService {
       throw Exception('Unauthorized');
     }
     return user.id;
-  }
-
-  static bool isRegistrationCompleted(supabase.User user) {
-    return SupabaseAuthService.isRegistrationCompleted(user);
   }
 }

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -6,6 +6,7 @@ import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/repositories/user_metadata_repository/user_metadata_repository_remote.dart';
 import 'package:notiyou/services/auth/kakao_auth_service.dart';
 import 'package:notiyou/services/auth/supabase_auth_service.dart';
+import 'package:notiyou/services/user_metadata_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
 class AuthException implements Exception {
@@ -135,15 +136,5 @@ class AuthService {
 
   static bool isRegistrationCompleted(supabase.User user) {
     return SupabaseAuthService.isRegistrationCompleted(user);
-  }
-
-  static RegistrationStatus getRegistrationStatus(supabase.User user) {
-    // for testing
-    // TODO: static class 제거 이후 제거
-    if (_testRole != null) {
-      return RegistrationStatus(registeredRole: _testRole!);
-    }
-
-    return SupabaseAuthService.getRegistrationStatus(user);
   }
 }

--- a/lib/services/auth/supabase_auth_service.dart
+++ b/lib/services/auth/supabase_auth_service.dart
@@ -1,4 +1,3 @@
-import 'package:notiyou/models/registration_status.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 import 'package:notiyou/services/supabase_service.dart';
 
@@ -17,36 +16,5 @@ class SupabaseAuthService {
 
   static Future<supabase.User?> getUser() async {
     return SupabaseService.client.auth.currentUser;
-  }
-
-  static Future<void> setRole(UserRole role) async {
-    final userMetadata =
-        SupabaseService.client.auth.currentUser?.userMetadata ?? {};
-    // TODO: Add error handling for updateUser operation
-    await SupabaseService.client.auth.updateUser(
-      supabase.UserAttributes(
-        data: {
-          ...userMetadata,
-          'registered_role': role.name,
-        },
-      ),
-    );
-  }
-
-  static bool isRegistrationCompleted(supabase.User user) {
-    final registrationStatus = getRegistrationStatus(user);
-    return registrationStatus.registeredRole != UserRole.none;
-  }
-
-  static RegistrationStatus getRegistrationStatus(supabase.User user) {
-    if (user.userMetadata == null) {
-      return RegistrationStatus(
-        registeredRole: UserRole.none,
-      );
-    }
-
-    return RegistrationStatus.fromString(
-      user.userMetadata!['registered_role'],
-    );
   }
 }

--- a/lib/services/challenger_config_service.dart
+++ b/lib/services/challenger_config_service.dart
@@ -55,22 +55,26 @@ class ChallengerConfigService {
 
   static Future<ChallengerSupporter> dismissSupporter() async {
     final userId = await _getAuthorizedUserId();
-    final supporter =
-        await _repository.getChallengerSupporterBySupporterId(userId);
+    final challengerSupporterInfo =
+        await _repository.getChallengerSupporterByChallengerId(userId);
+    final supporterId = challengerSupporterInfo.supporterId;
+    if (supporterId == null) {
+      throw ChallengerSupporterException('서포터 정보가 없습니다.');
+    }
 
     try {
       final result = await _repository.updateChallengerSupporter(
         challengerId: userId,
         supporterId: null,
       );
-      await UserMetadataService.setRole(supporter.id, UserRole.none);
+      await UserMetadataService.setRole(supporterId, UserRole.none);
       return result;
     } catch (e) {
       await _repository.updateChallengerSupporter(
         challengerId: userId,
-        supporterId: supporter.id,
+        supporterId: supporterId,
       );
-      await UserMetadataService.setRole(supporter.id, UserRole.supporter);
+      await UserMetadataService.setRole(supporterId, UserRole.supporter);
       throw ChallengerSupporterException('서포터 해제 중 오류가 발생했습니다: $e');
     }
   }

--- a/lib/services/challenger_config_service.dart
+++ b/lib/services/challenger_config_service.dart
@@ -3,6 +3,7 @@ import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/repositories/challenger_supporter/challenger_supporter_repository_remote.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:notiyou/exceptions/challenger_supporter_exception.dart';
+import 'package:notiyou/services/user_metadata_service.dart';
 
 class ChallengerConfigService {
   static final _repository = ChallengerSupporterRepositoryRemote();
@@ -64,11 +65,11 @@ class ChallengerConfigService {
   static Future<void> quitSupporter() async {
     try {
       final userId = await AuthService.getUserId();
-      await AuthService.setRole(UserRole.none);
+      await UserMetadataService.setRole(userId, UserRole.none);
       try {
         await _repository.dismissChallengerSupporterBySupporterId(userId);
       } catch (e) {
-        await AuthService.setRole(UserRole.supporter);
+        await UserMetadataService.setRole(userId, UserRole.supporter);
         throw ChallengerSupporterException('서포터 해제 중 오류가 발생했습니다: $e');
       }
     } catch (e) {

--- a/lib/services/invite_deep_link_service.dart
+++ b/lib/services/invite_deep_link_service.dart
@@ -4,6 +4,7 @@ import 'package:notiyou/services/challenger_code/challenger_code_service.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_service_interface.dart';
 import 'package:notiyou/services/dotenv_service.dart';
 import 'package:notiyou/routes/router.dart';
+import 'package:notiyou/services/user_metadata_service.dart';
 
 enum InvitedUserStatus {
   guest,
@@ -93,13 +94,10 @@ class InviteDeepLinkService {
   }
 
   static Future<InvitedUserStatus> _getUserStatus() async {
-    final user = await AuthService.getUser();
+    final isRoleRegistered =
+        await UserMetadataService.isRoleRegistrationCompleted();
 
-    if (user == null) {
-      return InvitedUserStatus.guest;
-    }
-
-    if (AuthService.isRegistrationCompleted(user)) {
+    if (isRoleRegistered) {
       return InvitedUserStatus.registeredUser;
     }
 

--- a/lib/services/invite_deep_link_service.dart
+++ b/lib/services/invite_deep_link_service.dart
@@ -1,5 +1,4 @@
 import 'package:app_links/app_links.dart';
-import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_service.dart';
 import 'package:notiyou/services/challenger_code/challenger_code_service_interface.dart';
 import 'package:notiyou/services/dotenv_service.dart';

--- a/lib/services/user_metadata_service.dart
+++ b/lib/services/user_metadata_service.dart
@@ -13,7 +13,7 @@ class UserMetadataService {
     return await userMetadataRepository.getRole(userId);
   }
 
-  static Future<bool> isRegistrationCompleted() async {
+  static Future<bool> isRoleRegistrationCompleted() async {
     final userId = await AuthService.getUserId();
     final role = await getRole(userId);
     return role != UserRole.none;

--- a/lib/services/user_metadata_service.dart
+++ b/lib/services/user_metadata_service.dart
@@ -1,0 +1,14 @@
+import 'package:notiyou/models/registration_status.dart';
+import 'package:notiyou/repositories/user_metadata_repository/user_metadata_repository_remote.dart';
+
+class UserMetadataService {
+  static final userMetadataRepository = UserMetadataRepositoryRemote();
+
+  static Future<void> setRole(String userId, UserRole role) async {
+    await userMetadataRepository.updateRole(userId, role);
+  }
+
+  static Future<UserRole> getRole(String userId) async {
+    return await userMetadataRepository.getRole(userId);
+  }
+}

--- a/lib/services/user_metadata_service.dart
+++ b/lib/services/user_metadata_service.dart
@@ -1,5 +1,6 @@
 import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/repositories/user_metadata_repository/user_metadata_repository_remote.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
 
 class UserMetadataService {
   static final userMetadataRepository = UserMetadataRepositoryRemote();
@@ -10,5 +11,11 @@ class UserMetadataService {
 
   static Future<UserRole> getRole(String userId) async {
     return await userMetadataRepository.getRole(userId);
+  }
+
+  static Future<bool> isRegistrationCompleted() async {
+    final userId = await AuthService.getUserId();
+    final role = await getRole(userId);
+    return role != UserRole.none;
   }
 }

--- a/lib/services/user_metadata_service.dart
+++ b/lib/services/user_metadata_service.dart
@@ -1,3 +1,4 @@
+import 'package:meta/meta.dart';
 import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/repositories/user_metadata_repository/user_metadata_repository_remote.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
@@ -10,6 +11,10 @@ class UserMetadataService {
   }
 
   static Future<UserRole> getRole(String userId) async {
+    if (testRole != null) {
+      return testRole!;
+    }
+
     return await userMetadataRepository.getRole(userId);
   }
 
@@ -17,5 +22,13 @@ class UserMetadataService {
     final userId = await AuthService.getUserId();
     final role = await getRole(userId);
     return role != UserRole.none;
+  }
+
+  @visibleForTesting
+  static UserRole? testRole;
+
+  @visibleForTesting
+  static void setRoleForTesting(UserRole role) {
+    testRole = role;
   }
 }

--- a/test/routes/guards/role_guard_test.dart
+++ b/test/routes/guards/role_guard_test.dart
@@ -7,6 +7,7 @@ import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/routes/guards/role_guard.dart';
 import 'package:notiyou/screens/login_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
+import 'package:notiyou/services/user_metadata_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
 class MockRouteGuard extends Mock implements RouteGuard {}
@@ -36,6 +37,8 @@ void main() {
     context = MockBuildContext();
     state = MockGoRouterState();
     mockUser = MockUser();
+
+    when(() => mockUser.id).thenReturn('test-user-id');
   });
 
   group('RoleGuard', () {
@@ -45,7 +48,7 @@ void main() {
           .thenAnswer((_) async => null);
 
       AuthService.setUserForTesting(mockUser);
-      AuthService.setRoleForTesting(UserRole.challenger);
+      UserMetadataService.setRoleForTesting(UserRole.challenger);
 
       // act
       final result = await roleGuard.canActivate(context, state, redirectPath);
@@ -64,7 +67,7 @@ void main() {
           .thenAnswer((_) async => null);
 
       AuthService.setUserForTesting(mockUser);
-      AuthService.setRoleForTesting(UserRole.supporter);
+      UserMetadataService.setRoleForTesting(UserRole.supporter);
 
       // act
       final result = await roleGuard.canActivate(context, state, redirectPath);
@@ -83,7 +86,7 @@ void main() {
           .thenAnswer((_) async => null);
 
       AuthService.setUserForTesting(mockUser);
-      AuthService.setRoleForTesting(UserRole.supporter);
+      UserMetadataService.setRoleForTesting(UserRole.supporter);
 
       // act
       final result = await roleGuard.canActivate(context, state, null);


### PR DESCRIPTION
## 요약
- Supabase Authentication의 metadata를 걷어내고, 별도의 user_metadata 테이블에서 사용자 role을 관리하도록 변경
- 도전자가 서포터 해제 시, 서포터의 role이 바뀌지 않던 문제 수정


## 작업 내용
- [refactor: AuthService의 role 사용을 UserMetadata의 role 사용하도록 교체](https://github.com/buku-buku/notiyou/pull/94/commits/c9112a97d7811f8f6a9a8c86730b412748ce933e)
  - UserMetadaService 추가 
  - 기존 role 정보를 조회하던 목적의 `AuthService.getRegistrationStatus` 사용처를 코드베이스 상에서 UserMetadaService.getRole로 대체. getRegistrationStatus 메서드 삭제
- [refactor: isRegistrationCompleted를 AuthService에서 UserMetadaService로 이관](https://github.com/buku-buku/notiyou/pull/94/commits/70436725dbc1f12b0b00e91ef9880669b68c0d1f)
  - SupabaseAuthService의 메서드 setRole을 제거 -> user_metadata의 updateRole로 대체
  - SupabaseAuthService의 메서드 isRegistrationCompleted, getRegistrationStatus 제거 -> UserMetadaService의 isRegistrationCompleted로 대체

- [feat: 서포터 해제 시 서포터의 role도 초기화](https://github.com/buku-buku/notiyou/pull/94/commits/bc92030b76b8410941689b3d31c971197b479933)
  - 도전자가 서포터 해제하기(dismissSupporter) 실행 시, user_metadata 테이블에서 서포터의 role을 none으로 초기화
- [fix: 메서드명 오타 수정](https://github.com/buku-buku/notiyou/pull/94/commits/635fb1d79b812f9e43d1de727fe214bbae1fb788), [fix: 도전자의 서포터 정보를 도전자id로 조회하도록 수정](https://github.com/buku-buku/notiyou/pull/94/commits/9e508a465c7a22aade95e8b05d5e1228d1b51899)
  - 단순 휴먼에러 수정
- [test: roleGuard 테스트에 UserMetadaService 사용하도록 대응](https://github.com/buku-buku/notiyou/pull/94/commits/b99ba4a543ddc5c5c97a2b0e79892ce9546b6595)
  - 테스트코드 변경 대응

## 기타 사항

- 버그 발견: 도전자가 해제'당했'을 시, signup 페이지로 튕겨나가야 하는데 login 페이지로 튕겨나감 
- policy 이슈가 있었음
  - update 정책을 restrictive로 설정했더니 안됐음
```
// 회원가입 후 최초 서포터 등록 시 setRole supporter 잘 됨
// 도전자가 나를 해제했을 때 setRole none 잘 됨
// 근데 내가 다시 서포터를 등록하려고하면 setRole supporter 안됨
```
- TODO
  - 추후 보다 부드러운 UX 제공 필요: 현재는 서포터 해제를 당한 경우 다음 클릭 시 튕겨나감

## 체크리스트



## 스크린샷




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 새로운 사용자 역할 관리 서비스가 도입되어, 사용자 역할 조회 및 업데이트 기능이 강화되었습니다.
- **Refactor**
	- 사용자 역할 관련 처리 로직이 비동기 방식으로 전환되어 로그인, 시작 화면 및 설정 과정의 안정성이 개선되었습니다.
	- 지원자 및 챌린저 역할 변경 시 개선된 오류 처리로 사용자 경험이 향상되었습니다.
- **Tests**
	- 역할 설정 테스트가 새 시스템에 맞게 업데이트되어 일관성과 신뢰성이 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->