### PR TITLE
[NY-162] 카톡 초대 메시지에 도전자의 코드 표시

### DIFF
--- a/lib/widgets/supporter_section.dart
+++ b/lib/widgets/supporter_section.dart
@@ -115,7 +115,11 @@ class _SupporterSectionState extends State<SupporterSection>
 
       final TextTemplate defaultText = TextTemplate(
         objectType: 'text',
-        text: '${_participant?.name}님의 미션 서포터가 되어주시겠습니까?',
+        text: '${_participant?.name}님의 미션 서포터가 되어주시겠습니까?\n\n'
+            '${_participant?.name}님의 초대코드\n'
+            '━━━━━━━━━━━━━━\n'
+            '$challengerCode\n'
+            '━━━━━━━━━━━━━━',
         buttonTitle: '서포터 등록하기',
         link: Link(
             mobileWebUrl: Uri.parse(inviteLink),


### PR DESCRIPTION
## 요약
카톡 초대 메시지에 도전자의 코드 표시


## 작업 내용


## 기타 사항

## 체크리스트

## 스크린샷
![IMG_3F500D44BB8D-1](https://github.com/user-attachments/assets/824b024c-1852-4b30-81bd-fddfbb8a091b)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 공유 메시지에 참가자의 초대 코드가 보기 쉽게 추가되어, 미션 서포터 초대 시 더 많은 정보를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->