### PR TITLE
[NY-177] 해제당한 서포터가 역할선택 화면이 아니라 로그인페이지로 튕겨지는 문제

### DIFF
--- a/lib/routes/guards/role_guard.dart
+++ b/lib/routes/guards/role_guard.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:notiyou/core/routes/guards/route_guard.dart';
 import 'package:notiyou/models/registration_status.dart';
-import 'package:notiyou/screens/login_page.dart';
+import 'package:notiyou/screens/signup_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:notiyou/services/user_metadata_service.dart';
 
@@ -19,7 +19,7 @@ class RoleGuard extends RouteGuardDecorator {
       return result;
     }
 
-    result = redirectPath ?? LoginPage.routeName;
+    result = redirectPath ?? SignupPage.routeName;
 
     final user = await AuthService.getUser();
     if (user == null) {

--- a/test/routes/guards/role_guard_test.dart
+++ b/test/routes/guards/role_guard_test.dart
@@ -5,7 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:notiyou/core/routes/guards/route_guard.dart';
 import 'package:notiyou/models/registration_status.dart';
 import 'package:notiyou/routes/guards/role_guard.dart';
-import 'package:notiyou/screens/login_page.dart';
+import 'package:notiyou/screens/signup_page.dart';
 import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:notiyou/services/user_metadata_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
@@ -80,7 +80,7 @@ void main() {
       AuthService.clearUserForTesting();
     });
 
-    test('redirectPath가 null이면 LoginPage.routeName으로 리디렉션해야 한다', () async {
+    test('redirectPath가 null이면 SignupPage.routeName으로 리디렉션해야 한다', () async {
       // arrange
       when(() => mockGuard.canActivate(any(), any(), null))
           .thenAnswer((_) async => null);
@@ -92,7 +92,7 @@ void main() {
       final result = await roleGuard.canActivate(context, state, null);
 
       // assert
-      expect(result, equals(LoginPage.routeName));
+      expect(result, equals(SignupPage.routeName));
       verify(() => mockGuard.canActivate(context, state, null)).called(1);
 
       AuthService.clearUserForTesting();


### PR DESCRIPTION
## 요약
- role guard에서 허용된 역할이 아니면 SignupPage로 리다이렉트 되도록 수정


## 작업 내용


## 기타 사항


## 체크리스트


## 스크린샷



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 인증되지 않았거나 권한이 없는 사용자가 로그인 페이지 대신 회원가입 페이지로 리디렉션되도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->