### PR TITLE
[NY-170] 서포터 설정 페이지 bottom nav의 active 상태가 맞지 않는 문제

### DIFF
--- a/lib/routes/index.dart
+++ b/lib/routes/index.dart
@@ -147,6 +147,12 @@ final List<GoRoute> bottomNavigationRoutes = [
 int _calculateSelectedIndex(BuildContext context) {
   final String location =
       GoRouter.of(context).routerDelegate.currentConfiguration.uri.toString();
+
+  if (location == ChallengerConfigPage.routeName ||
+      location == SupporterConfigPage.routeName) {
+    return 2;
+  }
+
   return bottomNavigationRoutes
       .indexWhere((route) => location.startsWith(route.path));
 }

--- a/lib/routes/index.dart
+++ b/lib/routes/index.dart
@@ -101,6 +101,14 @@ final routes = <RouteBase>[
   ),
 ];
 
+// 라우트 경로와 네비게이션 인덱스 매핑
+final Map<String, int> routeIndexMap = {
+  HomePage.routeName: 0,
+  HistoryPage.routeName: 1,
+  ChallengerConfigPage.routeName: 2,
+  SupporterConfigPage.routeName: 2,
+};
+
 final List<GoRoute> bottomNavigationRoutes = [
   GoRouteWithGuards(
     path: HomePage.routeName,
@@ -148,11 +156,5 @@ int _calculateSelectedIndex(BuildContext context) {
   final String location =
       GoRouter.of(context).routerDelegate.currentConfiguration.uri.toString();
 
-  if (location == ChallengerConfigPage.routeName ||
-      location == SupporterConfigPage.routeName) {
-    return 2;
-  }
-
-  return bottomNavigationRoutes
-      .indexWhere((route) => location.startsWith(route.path));
+  return routeIndexMap[location] ?? 3;
 }


### PR DESCRIPTION
## 요약
- bottomNavigationRoutes의 index로 현재 active한 탭을 표시하는데, 서포터 설정페이지의 index가 2를 반환해야함
- list 타입인 경우 route가 추가될때마다 index가 달라지기 때문에 단순하게 페이지의 index를 직접 지정하여 관리하는 방식으로 수정 


## 작업 내용

## 기타 사항


## 체크리스트


## 스크린샷
![스크린샷 2025-04-20 오후 3 23 50](https://github.com/user-attachments/assets/149a7848-f897-4a32-aa88-8bfbb4b99cf5)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 하단 내비게이션에서 현재 위치에 따른 선택 인덱스 계산 방식이 개선되어, 경로 인식이 더욱 정확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->