### PR TITLE
[NY-82] fix: 미션 완료시 해당 미션의 알람을 취소하도록 설정

### DIFF
--- a/lib/services/mission_history_service.dart
+++ b/lib/services/mission_history_service.dart
@@ -2,6 +2,7 @@ import 'package:notiyou/models/mission.dart';
 import 'package:notiyou/repositories/mission_history_repository/mission_history_repository_interface.dart';
 import 'package:notiyou/repositories/mission_history_repository/mission_history_repository_local.dart';
 import 'package:notiyou/repositories/mission_history_repository/mission_history_repository_remote.dart';
+import 'package:notiyou/services/mission_alarm_service.dart';
 
 class MissionHistoryService {
   static MissionHistoryRepository _missionHistoryRepository =
@@ -32,6 +33,11 @@ class MissionHistoryService {
 
     // 변경된 데이터 저장
     await _missionHistoryRepository.updateMission(updatedMission);
+
+    // 미션이 완료되었을 경우 알람 취소
+    if (newIsCompleted) {
+      await MissionAlarmService.cancelAlarm(missionId);
+    }
 
     // 변경된 미션의 새로운 상태 반환
     return updatedMission.isCompleted;


### PR DESCRIPTION
## 요약

- 미션 완료 처리가 될때 해당 미션에 대해 설정한 로컬 알람 설정을 취소하도록 처리합니다.
- 별개의 문제인 "하루치의 알람만을 생성하기 때문에, 그 날에 앱에 접속한적이 없으면 그 날 알람이 안 울리는 문제"도 함께 해소하려고 했는데, 고생고생하다가 우선은 포기했습니다.


## 작업 내용

- [fix: 미션 완료시 해당 미션의 알람을 취소하도록 설정](https://github.com/buku-buku/notiyou/pull/99/commits/6defd996da29bdd86cf6aab8e752a05c7ceabb2b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 미션 완료 시 해당 미션과 연동된 알람이 자동으로 취소됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->