### PR TITLE
[NY-183] 최초 실행 시 스플래시 페이지에서 진행이 안되던 문제

### DIFF
--- a/lib/services/firebase/firebase_service.dart
+++ b/lib/services/firebase/firebase_service.dart
@@ -31,9 +31,17 @@ class FirebaseService {
 
         // For apple platforms, ensure the APNS token is available before making any FCM plugin API calls
         if (Platform.isIOS) {
-          final apnsToken = await FirebaseMessaging.instance.getAPNSToken();
+          String? apnsToken;
+          const maxAttempts = 20;
+          for (var i = 0; i < maxAttempts; i++) {
+            apnsToken = await FirebaseMessaging.instance.getAPNSToken();
+            if (apnsToken != null) {
+              break;
+            }
+            await Future.delayed(const Duration(seconds: 1));
+          }
           if (apnsToken == null) {
-            throw Exception('firebase_service: apnsToken is null');
+            throw Exception('firebase_service: Problem with getting apnsToken');
           }
         }
 


### PR DESCRIPTION
## 요약
- 앱을 최초로 디바이스에 설치하면 splash Page에서 진행이 안됨
  - 현상: 재설치시 정상 동작함
  - 원인: firebase APNS token is null. 최초에 토큰이 초기화 되지 않는듯
  - 해결: token을 얻을 때까지  재시도


## 작업 내용

- 커밋을 기준으로 설명합니다.

## 기타 사항

- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등을 설명합니다.

## 체크리스트

- Merge/배포 후에 체크해야 할 사항이 있으면 적어주세요.

## 스크린샷

- 필요시, 추가되는 기능이나 고친 버그 등을 잘 보여주는 스크린샷을 첨부합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - iOS에서 APNS 토큰을 더 안정적으로 획득할 수 있도록 토큰 획득 시 재시도 로직이 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->