### PR TITLE
[NY-167][NY-163] 도전자가 미션 취소 시, 확인 alert 띄우기. 헬퍼 문구 수정

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -189,8 +189,31 @@ Widget buildChallengerView(
                   : null,
               trailing: Checkbox(
                 value: mission.isCompleted,
-                onChanged: (bool? value) {
-                  onToggleMissionComplete(mission.id);
+                onChanged: (bool? value) async {
+                  if (mission.isCompleted) {
+                    final confirmed = await showDialog<bool>(
+                      context: context,
+                      builder: (context) => AlertDialog(
+                        title: const Text('주의'),
+                        content: const Text('이미 완료 처리한 미션입니다.\n정말 되돌리겠습니까?'),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(false),
+                            child: const Text('아니오'),
+                          ),
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(true),
+                            child: const Text('예'),
+                          ),
+                        ],
+                      ),
+                    );
+                    if (confirmed == true) {
+                      onToggleMissionComplete(mission.id);
+                    }
+                  } else {
+                    onToggleMissionComplete(mission.id);
+                  }
                 },
               )),
         ],

--- a/lib/widgets/notification_template_config.dart
+++ b/lib/widgets/notification_template_config.dart
@@ -120,6 +120,13 @@ class _NotificationTemplateConfigState
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       const Text('미션 성공 알림 메시지'),
+                      const Text(
+                        '*미션 완료 시, 서포터에게 전송될 문구입니다',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Colors.black54,
+                        ),
+                      ),
                       const SizedBox(height: 8),
                       TextFormField(
                         controller: _successController,
@@ -128,7 +135,6 @@ class _NotificationTemplateConfigState
                         decoration: const InputDecoration(
                           border: OutlineInputBorder(),
                           hintText: '미션 성공 시 전송될 알림 메시지를 입력하세요',
-                          helperText: '예: [이름]님이 미션을 성공적으로 완료했습니다!',
                         ),
                         validator: (value) {
                           if (value == null || value.isEmpty) {
@@ -139,6 +145,13 @@ class _NotificationTemplateConfigState
                       ),
                       const SizedBox(height: 16),
                       const Text('미션 실패 알림 메시지'),
+                      const Text(
+                        '*정해진 시간에 미션을 완료하지 못한 경우, 서포터에게 전송될 문구입니다',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Colors.black54,
+                        ),
+                      ),
                       const SizedBox(height: 8),
                       TextFormField(
                         controller: _failureController,
@@ -147,7 +160,6 @@ class _NotificationTemplateConfigState
                         decoration: const InputDecoration(
                           border: OutlineInputBorder(),
                           hintText: '미션 실패 시 전송될 알림 메시지를 입력하세요',
-                          helperText: '예: [이름]님이 미션 수행에 실패했습니다.',
                         ),
                         validator: (value) {
                           if (value == null || value.isEmpty) {


### PR DESCRIPTION
## 요약
- 도전자가 이미 완료한 미션을 취소 시, 재확인  하는 모달 띄우기


## 작업 내용



## 기타 사항



## 체크리스트



## 스크린샷

https://github.com/user-attachments/assets/578236f8-0f8b-41ea-95a6-532f0dc660b0

![스크린샷 2025-04-28 오전 12 07 30](https://github.com/user-attachments/assets/10753cd8-16e2-44e1-891e-bc5a6dcd9e65)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 완료된 미션을 체크 해제할 때 확인 대화상자가 표시되어, 사용자가 의도하지 않게 완료 상태를 변경하지 않도록 안내합니다.  
- **사용성 개선**
    - 미션 완료 상태를 해제할 경우 "예" 또는 "아니오" 선택지를 통해 변경을 한 번 더 확인할 수 있습니다.
    - 미션 성공 및 실패 알림 메시지 입력란 아래에 각각의 메시지 용도를 설명하는 도움말 텍스트가 추가되어 이해를 돕습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->