### PR TITLE
[NY-181] feat: 미션 알림 스케쥴링시, 10일치의 미션 알림을 생성하도록 수정

### DIFF
--- a/lib/services/firebase/firebase_service.dart
+++ b/lib/services/firebase/firebase_service.dart
@@ -62,6 +62,7 @@ class FirebaseService {
           }
 
           LocalNotificationService.showNotification(
+            id: message.messageId.hashCode,
             title: message.notification?.title,
             body: message.notification?.body,
             notificationType: message.data['notification_type'],

--- a/lib/services/local_notification_service.dart
+++ b/lib/services/local_notification_service.dart
@@ -37,8 +37,6 @@ class LocalNotificationService {
   static final NotificationHandler _notificationHandler =
       NotificationHandlerImpl();
 
-  static int _notificationId = 0;
-
   static Future<void> init() async {
     await _initializeTimeZone();
     await _initializeSettings();
@@ -83,17 +81,36 @@ class LocalNotificationService {
         );
   }
 
-  static Future<int> scheduleNotification({
-    int? id,
+  static Future<void> scheduleNotificationInterval({
+    required int id,
+    required String title,
+    required String body,
+    required DateTime scheduledTime,
+    required String notificationType,
+    required int count,
+  }) async {
+    var time = tz.TZDateTime.from(scheduledTime, tz.local);
+    for (var i = 0; i < count; i++) {
+      time = time.add(Duration(days: i));
+      await _scheduleNotification(
+        id: _createIdByDate(i, time),
+        title: title,
+        body: body,
+        scheduledTime: time,
+        notificationType: notificationType,
+      );
+    }
+  }
+
+  static Future<int> _scheduleNotification({
+    required int id,
     required String title,
     required String body,
     required DateTime scheduledTime,
     required String notificationType,
   }) async {
-    final newId = id ?? _notificationId++;
-
     await _notifications.zonedSchedule(
-      newId,
+      id,
       title,
       body,
       tz.TZDateTime.from(scheduledTime, tz.local),
@@ -104,11 +121,17 @@ class LocalNotificationService {
       payload: notificationType,
     );
 
-    return newId;
+    return id;
   }
 
   static Future<void> cancelNotification(int id) async {
-    await _notifications.cancel(id);
+    final today = DateTime.now();
+    final idToCancel = _createIdByDate(id, today);
+    await _notifications.cancel(idToCancel);
+  }
+
+  static int _createIdByDate(int id, DateTime date) {
+    return "$id${date.year}${date.month}${date.day}".hashCode;
   }
 
   static Future<void> cancelAllNotifications() async {
@@ -116,13 +139,13 @@ class LocalNotificationService {
   }
 
   static Future<void> showNotification({
-    int? id,
+    required int id,
     String? title = '테스트 알림',
     String? body = '이것은 테스트 알림입니다.',
     String? notificationType,
   }) async {
     await _notifications.show(
-      id ?? _notificationId++,
+      _createIdByDate(id, DateTime.now()),
       title,
       body,
       notificationDetails,

--- a/lib/services/local_notification_service.dart
+++ b/lib/services/local_notification_service.dart
@@ -89,9 +89,9 @@ class LocalNotificationService {
     required String notificationType,
     required int count,
   }) async {
-    var time = tz.TZDateTime.from(scheduledTime, tz.local);
     for (var i = 0; i < count; i++) {
-      time = time.add(Duration(days: i));
+      final time =
+          tz.TZDateTime.from(scheduledTime.add(Duration(days: i)), tz.local);
       await _scheduleNotification(
         id: _createIdByDate(i, time),
         title: title,

--- a/lib/services/mission_alarm_service.dart
+++ b/lib/services/mission_alarm_service.dart
@@ -38,6 +38,7 @@ class MissionAlarmService {
     }
   }
 
+  /// 10일 동안의 알람을 설정합니다.
   static Future<void> scheduleAlarm(
       int missionId, TimeOfDay missionTime) async {
     final now = DateTime.now();
@@ -53,11 +54,12 @@ class MissionAlarmService {
       scheduledTime = scheduledTime.add(const Duration(days: 1));
     }
 
-    await LocalNotificationService.scheduleNotification(
+    await LocalNotificationService.scheduleNotificationInterval(
       id: missionId,
       title: '미션 알림',
       body: '미션 시간입니다!',
       scheduledTime: scheduledTime,
+      count: 10,
       notificationType: NotificationEvent.missionAlarm.value,
     );
   }

--- a/lib/services/mission_history_service.dart
+++ b/lib/services/mission_history_service.dart
@@ -37,6 +37,8 @@ class MissionHistoryService {
     // 미션이 완료되었을 경우 알람 취소
     if (newIsCompleted) {
       await MissionAlarmService.cancelAlarm(missionId);
+    } else {
+      await MissionAlarmService.scheduleAlarm(missionId, mission.time);
     }
 
     // 변경된 미션의 새로운 상태 반환


### PR DESCRIPTION
## 요약

도전자를 위한 미션 로컬 알림은 앱을 처음 켰을때 생성하게 됩니다.
기존에는 하루치만 생성하던 알림을 10일치 생성하도록 수정합니다.

## 작업 내용

- [feat: 미션 알림 스케쥴링시, 10일치의 미션 알림을 생성하도록 수정](https://github.com/buku-buku/notiyou/pull/103/commits/d8da21354bfe759c4f25bd40c6c296a8d37322d1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 미션 알람이 10일간 반복적으로 예약됩니다.
- **버그 수정**
	- 미션을 미완료로 변경할 때 알람이 다시 활성화됩니다.
- **개선 사항**
	- 알림 ID가 날짜와 연동되어 매일 고유하게 생성되어, 알림 예약·취소·표시에 일관성이 향상되었습니다.
	- 푸시 알림 수신 시 각 알림이 고유 ID로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->