### PR TITLE
[Bug] 앱이 완전히 종료된 상태에서 초대링크 클릭 시, 스플래시 화면에 멈춰있던 문제

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,11 +23,12 @@ void main() async {
   );
   await SupabaseService.init();
   await FirebaseService.init();
+  runApp(const MyApp());
   await InviteDeepLinkService.init();
   await LocalNotificationService.init();
   await MissionConfigService.init();
   await MissionAlarmService.init();
-  runApp(const MyApp());
+  FlutterNativeSplash.remove();
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/services/firebase/firebase_service.dart
+++ b/lib/services/firebase/firebase_service.dart
@@ -45,6 +45,21 @@ class FirebaseService {
           }
         }
 
+        // 앱 종료 상태에서 푸시 알림 처리
+        final initialMessage =
+            await FirebaseMessaging.instance.getInitialMessage();
+        if (initialMessage != null) {
+          if (initialMessage.notification == null) {
+            throw Exception(
+                'firebase_service: initialMessage.notification is null');
+          }
+
+          final event = NotificationEvent.getNotificationEvent(
+              initialMessage.data['notification_type']);
+
+          _notificationHandler.handleNotification(event, initialMessage.data);
+        }
+        // 앱 백그라운드 실행 상태에서 푸시 알림 처리
         FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
           if (message.notification == null) {
             throw Exception('firebase_service: message.notification is null');
@@ -55,7 +70,7 @@ class FirebaseService {
 
           _notificationHandler.handleNotification(event, message.data);
         });
-
+        // 앱 포그라운드 실행 상태에서 푸시 알림 처리
         FirebaseMessaging.onMessage.listen((RemoteMessage message) {
           if (message.notification == null) {
             throw Exception('firebase_service: message.notification is null');

--- a/lib/services/firebase/firebase_service.dart
+++ b/lib/services/firebase/firebase_service.dart
@@ -49,32 +49,27 @@ class FirebaseService {
         final initialMessage =
             await FirebaseMessaging.instance.getInitialMessage();
         if (initialMessage != null) {
-          if (initialMessage.notification == null) {
-            throw Exception(
-                'firebase_service: initialMessage.notification is null');
-          }
+          _validateNotification(initialMessage);
 
           final event = NotificationEvent.getNotificationEvent(
               initialMessage.data['notification_type']);
 
           _notificationHandler.handleNotification(event, initialMessage.data);
         }
+
         // 앱 백그라운드 실행 상태에서 푸시 알림 처리
         FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
-          if (message.notification == null) {
-            throw Exception('firebase_service: message.notification is null');
-          }
+          _validateNotification(message);
 
           final event = NotificationEvent.getNotificationEvent(
               message.data['notification_type']);
 
           _notificationHandler.handleNotification(event, message.data);
         });
+
         // 앱 포그라운드 실행 상태에서 푸시 알림 처리
         FirebaseMessaging.onMessage.listen((RemoteMessage message) {
-          if (message.notification == null) {
-            throw Exception('firebase_service: message.notification is null');
-          }
+          _validateNotification(message);
 
           LocalNotificationService.showNotification(
             id: message.messageId.hashCode,
@@ -123,5 +118,11 @@ class FirebaseService {
       await Future.delayed(const Duration(seconds: 10));
     }
     throw Exception('firebase_service: 사용자 인증 대기 시간이 초과되었습니다.');
+  }
+
+  static void _validateNotification(RemoteMessage message) {
+    if (message.notification == null) {
+      throw Exception('firebase_service: message.notification is null');
+    }
   }
 }


### PR DESCRIPTION
## 요약
- 앱이 종료된 상태에서 푸시알림을 클릭 시, 각 event에 맞는 페이지로 사용자를 redirect하도록 하는 핸들러 추가
- 앱이 종료된 상태에서 초대링크를 누르면 스플래시 화면에서 멈춰서 진행이 안되는 문제가 있었음
  - [이슈 노트](https://github.com/buku-buku/notiyou/issues/104)

## 작업 내용
- [fix: FlutterNativeSplash.remove를 deeplink 처리 후 명시적 호출](https://github.com/buku-buku/notiyou/pull/105/commits/64a55818e4b230729437e86761070c8fafb33894)
  - 스플래시 화면에서의 버그 수정
- [feat: 앱이 종료된 상태에서 firebase 푸시알림 클릭 시 핸들링](https://github.com/buku-buku/notiyou/pull/105/commits/28fe4f3b72b2acdeba6295175cff75d81d472398)
  - 앱 종료된 상태에서 firebase 푸시알림 핸들링 추가
- [refactor: 중복 코드 리팩터링](https://github.com/buku-buku/notiyou/pull/105/commits/a17028831ddba466ec92c5837d10290db4ab9f28)

## 기타 사항


## 체크리스트


## 스크린샷



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **개선 사항**
  - 앱이 더 빠르게 실행되도록 초기화 순서가 조정되었습니다. 이제 앱 실행 후 일부 서비스가 백그라운드에서 초기화되며, 모든 서비스 초기화가 완료된 후 스플래시 화면이 사라집니다.
  - 앱이 종료된 상태에서도 푸시 알림을 수신하고 처리할 수 있도록 알림 기능이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->