### PR TITLE
[NY-165] 백그라운드 상태에서 푸시알림 클릭 시, 선택된  BottomNavigation 잘못 보여지는 문제

### DIFF
--- a/lib/services/notification/notification_handler.dart
+++ b/lib/services/notification/notification_handler.dart
@@ -28,22 +28,22 @@ class NotificationHandlerImpl implements NotificationHandler {
   }
 
   void _handleMissionSuccessNotification(Map<String, dynamic> data) {
-    router.push(HistoryPage.routeName);
+    router.go(HistoryPage.routeName);
   }
 
   void _handleMissionFailedNotification(Map<String, dynamic> data) {
-    router.push(HistoryPage.routeName);
+    router.go(HistoryPage.routeName);
   }
 
   void _handleSupporterAssignedNotification(Map<String, dynamic> data) {
-    router.push(ChallengerConfigPage.routeName);
+    router.go(ChallengerConfigPage.routeName);
   }
 
   void _handleSupporterDismissedNotification(Map<String, dynamic> data) {
-    router.push(ChallengerConfigPage.routeName);
+    router.go(ChallengerConfigPage.routeName);
   }
 
   void _handleMissionAlarmNotification(Map<String, dynamic> data) {
-    router.push(HomePage.routeName);
+    router.go(HomePage.routeName);
   }
 }


### PR DESCRIPTION
## 요약
- 푸시알림 핸들링 시, 의도된 페이지로 사용자를 보낼때 router.push를 사용하고 있는데 이 경우 path가 변경되지 않음 -> router.go를 사용하도록 변경
- 커서의 조언
![스크린샷 2025-05-10 오후 7 33 51](https://github.com/user-attachments/assets/6cddc180-f8e9-4feb-b6ee-7a0817af6651)


## 작업 내용


## 기타 사항


## 체크리스트


## 스크린샷


https://github.com/user-attachments/assets/af305077-ae97-41c0-a3c5-8f3a92f8b6e0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 알림 처리 시 페이지 이동 방식이 개선되어, 알림 클릭 시 더 자연스럽게 해당 화면으로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->