### PR TITLE
[NY-193] feat: 회원 탈퇴 기능 추가

### DIFF
--- a/lib/repositories/supabase_table_names_constants.dart
+++ b/lib/repositories/supabase_table_names_constants.dart
@@ -6,4 +6,5 @@ final class SupabaseTableNames {
   static const missionTime = 'mission_time';
   static const challengerSupporter = 'challenger_supporter';
   static const userMetadata = 'user_metadata';
+  static const userDeletionRequest = 'user_deletion_request';
 }

--- a/lib/repositories/user_deletion_request_repository/user_deletion_request_repository_interface.dart
+++ b/lib/repositories/user_deletion_request_repository/user_deletion_request_repository_interface.dart
@@ -1,0 +1,3 @@
+abstract class UserDeletionRequestRepositoryInterface {
+  Future<void> createUserDeletionRequest(String userId);
+}

--- a/lib/repositories/user_deletion_request_repository/user_deletion_request_repository_remote.dart
+++ b/lib/repositories/user_deletion_request_repository/user_deletion_request_repository_remote.dart
@@ -17,14 +17,10 @@ class UserDeletionRequestRepositoryRemote
 
   @override
   Future<void> createUserDeletionRequest(String userId) async {
-    print('createUserDeletionRequest: $userId');
     await SupabaseService.client
         .from(SupabaseTableNames.userDeletionRequest)
         .insert({
       'user_id': userId,
-    }).catchError((e) {
-      print('createUserDeletionRequest error: $e');
-      throw e;
     });
   }
 }

--- a/lib/repositories/user_deletion_request_repository/user_deletion_request_repository_remote.dart
+++ b/lib/repositories/user_deletion_request_repository/user_deletion_request_repository_remote.dart
@@ -1,0 +1,30 @@
+import 'package:notiyou/repositories/supabase_table_names_constants.dart';
+import 'package:notiyou/repositories/user_deletion_request_repository/user_deletion_request_repository_interface.dart';
+import 'package:notiyou/services/supabase_service.dart';
+
+class UserDeletionRequestRepositoryRemote
+    implements UserDeletionRequestRepositoryInterface {
+  static final UserDeletionRequestRepositoryRemote _instance =
+      UserDeletionRequestRepositoryRemote._internal();
+
+  UserDeletionRequestRepositoryRemote._internal();
+
+  factory UserDeletionRequestRepositoryRemote() {
+    return _instance;
+  }
+
+  static final supabaseClient = SupabaseService.client;
+
+  @override
+  Future<void> createUserDeletionRequest(String userId) async {
+    print('createUserDeletionRequest: $userId');
+    await SupabaseService.client
+        .from(SupabaseTableNames.userDeletionRequest)
+        .insert({
+      'user_id': userId,
+    }).catchError((e) {
+      print('createUserDeletionRequest error: $e');
+      throw e;
+    });
+  }
+}

--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -195,19 +195,81 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
               context: context,
               label: '알림 메시지 설정',
             ),
-            const SizedBox(height: 20),
+            const SizedBox(height: 16),
             buildSubmitButton(
               context: context,
               label: '설정 완료',
               isLoading: _isSubmitLoading,
               isEnabled: _isSubmittable() && !_isSubmitLoading,
               onSubmit: _handleSubmit,
-            )
+            ),
+            const SizedBox(height: 64),
+            buildDeleteAccountButton(context),
           ],
         ),
       ),
     );
   }
+}
+
+Widget buildDeleteAccountButton(BuildContext context) {
+  return ElevatedButton(
+    style: ElevatedButton.styleFrom(
+      backgroundColor: Colors.red,
+      foregroundColor: Colors.white,
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+    ),
+    onPressed: () async {
+      final bool? confirm = await showDialog<bool>(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text('※주의', style: TextStyle(color: Colors.red)),
+            content: const Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('정말 회원탈퇴 하시겠습니까?'),
+                SizedBox(height: 8),
+                Text(
+                  '회원탈퇴 시 모든 데이터가 삭제되며 복구할 수 없습니다.',
+                  style: TextStyle(color: Colors.red, fontSize: 12),
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('취소'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('확인'),
+              ),
+            ],
+          );
+        },
+      );
+      if (confirm == true) {
+        try {
+          await AuthService.deleteAccount();
+          if (!context.mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+                content: Text('회원탈퇴가 완료되었습니다.'),
+                duration: Duration(seconds: 2)),
+          );
+          context.go('/login');
+        } catch (e) {
+          if (!context.mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('회원탈퇴 중 오류가 발생했습니다: \n$e')),
+          );
+        }
+      }
+    },
+    child: const Text('회원탈퇴', style: TextStyle(fontSize: 16)),
+  );
 }
 
 Widget buildMissionTimeField({

--- a/lib/screens/supporter_config_page.dart
+++ b/lib/screens/supporter_config_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:notiyou/screens/signup_page.dart';
+import 'package:notiyou/services/auth/auth_service.dart';
 import 'package:notiyou/services/challenger_config_service.dart';
 
 class SupporterConfigPage extends StatelessWidget {
@@ -79,6 +80,66 @@ class SupporterConfigPage extends StatelessWidget {
                 '서포터 그만두기',
                 style: TextStyle(fontSize: 16),
               ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.red,
+                foregroundColor: Colors.white,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+              ),
+              onPressed: () async {
+                final bool? confirm = await showDialog<bool>(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return AlertDialog(
+                      title: const Text('※주의',
+                          style: TextStyle(color: Colors.red)),
+                      content: const Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text('정말 회원탈퇴 하시겠습니까?'),
+                          SizedBox(height: 8),
+                          Text(
+                            '회원탈퇴 시 모든 데이터가 삭제되며 복구할 수 없습니다.',
+                            style: TextStyle(color: Colors.red, fontSize: 12),
+                          ),
+                        ],
+                      ),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.of(context).pop(false),
+                          child: const Text('취소'),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.of(context).pop(true),
+                          child: const Text('확인'),
+                        ),
+                      ],
+                    );
+                  },
+                );
+                if (confirm == true) {
+                  try {
+                    await AuthService.deleteAccount();
+                    if (!context.mounted) return;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                          content: Text('회원탈퇴가 완료되었습니다.'),
+                          duration: Duration(seconds: 2)),
+                    );
+                    context.go('/login');
+                  } catch (e) {
+                    if (!context.mounted) return;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('회원탈퇴 중 오류가 발생했습니다: \n$e')),
+                    );
+                  }
+                }
+              },
+              child: const Text('회원탈퇴', style: TextStyle(fontSize: 16)),
             ),
           ],
         ),

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -2,6 +2,8 @@
 
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_talk.dart';
 import 'package:meta/meta.dart';
+import 'package:notiyou/repositories/user_deletion_request_repository/user_deletion_request_repository_interface.dart';
+import 'package:notiyou/repositories/user_deletion_request_repository/user_deletion_request_repository_remote.dart';
 import 'package:notiyou/repositories/user_metadata_repository/user_metadata_repository_remote.dart';
 import 'package:notiyou/services/auth/kakao_auth_service.dart';
 import 'package:notiyou/services/auth/supabase_auth_service.dart';
@@ -19,6 +21,8 @@ class AuthException implements Exception {
 // TODO: 테스트 용이성을 위해 static class 제거 필요. 이를 위해선 어플리케이션 레이어에서 DI Container 사용 필요.
 class AuthService {
   static final userMetadataRepository = UserMetadataRepositoryRemote();
+  static UserDeletionRequestRepositoryInterface userDeletionRequestRepository =
+      UserDeletionRequestRepositoryRemote();
 
   static Future<supabase.User?> loginWithKakao() async {
     // * 기존 로그인 상태 초기화
@@ -119,5 +123,10 @@ class AuthService {
       throw Exception('Unauthorized');
     }
     return user.id;
+  }
+
+  static Future<void> deleteAccount() async {
+    final userId = await getUserId();
+    await userDeletionRequestRepository.createUserDeletionRequest(userId);
   }
 }


### PR DESCRIPTION
## 요약

auth.users 테이블의 유저를 제거하려면, admin의 권한을 가지고 있어야합니다. [참고](https://supabase.com/docs/reference/javascript/auth-admin-deleteuser)  (flutter 문서에는 따로 명시되어있지 않으나 수행해보니 forbidden 처리됨)
따라서 유저 삭제 요청 테이블을 별도로 생성하여, 클라이언트에서는 해당 테이블에 요청을 넣고, supabase trigger를 이용해서 서버 내부적으로 관리자의 권한으로 삭제처리를 하는 방식으로 기능을 구현하였습니다.

- supabase database trigger 및 function을 이용하여 회원 탈퇴 기능 수행하도록 설정합니다.

1. `user_deletion_request` 테이블 추가
   - RLS 설정: 본인 user_id의 row만을 추가할 수 있다.
2. 해당 테이블에 row 추가시 관리자 권한으로 유저 삭제 동작을 수행하는 function, trigger 생성

참고: 
- [생성한 Database Table](https://supabase.com/dashboard/project/pmiivbdkefsnzznxghwb/editor/98892?schema=public)
- [생성한 Database Function](https://supabase.com/dashboard/project/pmiivbdkefsnzznxghwb/database/functions)

## 시연 영상

![화면 기록 2025-05-26 오후 4 47 15](https://github.com/user-attachments/assets/c25424f6-25bf-430b-892a-95448c20a34c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - 챌린저 및 서포터 설정 페이지에 "회원탈퇴" 버튼이 추가되었습니다. 버튼 클릭 시 영구적으로 계정 및 데이터가 삭제됨을 안내하는 확인 창이 표시되며, 탈퇴 성공 시 로그인 화면으로 이동하고 안내 메시지가 표시됩니다.
    - 회원탈퇴 요청 기능이 추가되어 사용자가 계정 삭제를 요청할 수 있습니다.
- **버그 수정**
    - 없음
- **기타**
    - 회원탈퇴 요청이 내부적으로 안전하게 처리되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->