### PR TITLE
[NY-192] 서포터 초대코드 복사하기 버튼 추가 / 설정 페이지 디자인 개편

### DIFF
--- a/lib/screens/challenger_config_page.dart
+++ b/lib/screens/challenger_config_page.dart
@@ -190,11 +190,11 @@ class _ChallengerConfigPageState extends State<ChallengerConfigPage> {
                 _selectedGracePeriod = newValue ?? 0;
               }),
             ),
-            if (!widget.isFirstTime) const SupporterSection(),
             buildSettingButton(
               context: context,
-              label: '알림 메시지 설정',
+              label: '알림 메시지 설정하기',
             ),
+            if (!widget.isFirstTime) const SupporterSection(),
             const SizedBox(height: 20),
             buildSubmitButton(
               context: context,
@@ -346,9 +346,21 @@ Widget buildSettingButton({
     );
   }
 
-  return ElevatedButton(
-    onPressed: () => showNotificationTemplateModal(),
-    child: Text(label),
+  return Container(
+    width: double.infinity,
+    margin: const EdgeInsets.symmetric(vertical: 8.0),
+    child: OutlinedButton.icon(
+      onPressed: () => showNotificationTemplateModal(),
+      icon: const Icon(Icons.notifications_outlined),
+      label: Text(label),
+      style: OutlinedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(vertical: 16.0),
+        side: const BorderSide(color: Colors.purple),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12.0),
+        ),
+      ),
+    ),
   );
 }
 
@@ -359,24 +371,43 @@ Widget buildSubmitButton({
   required bool isEnabled,
   required VoidCallback onSubmit,
 }) {
-  return ElevatedButton(
-    onPressed: isEnabled ? onSubmit : null,
-    child: isLoading
-        ? Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(label),
-              const SizedBox(width: 10),
-              const SizedBox(
-                width: 16,
-                height: 16,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: Colors.white,
+  return Container(
+    width: double.infinity,
+    margin: const EdgeInsets.symmetric(vertical: 8.0),
+    child: ElevatedButton(
+      onPressed: isEnabled ? onSubmit : null,
+      style: ElevatedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(vertical: 16.0),
+        backgroundColor: isEnabled ? Colors.blue : Colors.grey,
+        foregroundColor: Colors.white,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12.0),
+        ),
+        elevation: isEnabled ? 2 : 0,
+      ),
+      child: isLoading
+          ? Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(label),
+                const SizedBox(width: 12),
+                const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.white,
+                  ),
                 ),
+              ],
+            )
+          : Text(
+              label,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
               ),
-            ],
-          )
-        : Text(label),
+            ),
+    ),
   );
 }

--- a/lib/widgets/supporter_section.dart
+++ b/lib/widgets/supporter_section.dart
@@ -245,23 +245,63 @@ class _SupporterSectionState extends State<SupporterSection>
       children: [
         const SizedBox(height: 20),
         if (_challengerSupporterInfo?.supporterId == null) ...[
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              ElevatedButton(
-                onPressed: shareLinkToSupporter,
-                child: const Text('카카오톡으로 서포터 초대하기'),
+          Card(
+            elevation: 0,
+            margin: const EdgeInsets.symmetric(horizontal: 16),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                children: [
+                  const Text(
+                    '서포터 초대하기',
+                    style: TextStyle(
+                      color: Colors.blueAccent,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  const Text(
+                    '서포터를 초대하여 알람 공유 기능을 활성화하세요',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: Colors.black54,
+                      fontSize: 14,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton.icon(
+                      onPressed: shareLinkToSupporter,
+                      icon: const Icon(Icons.share),
+                      label: const Text('카카오톡으로 초대하기'),
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        backgroundColor: const Color(0xFFFEE500), // 카카오톡 색상
+                        foregroundColor: Colors.black87,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton.icon(
+                      onPressed: copyCodeToClipboard,
+                      icon: const Icon(Icons.copy),
+                      label: const Text('초대코드 복사하기'),
+                      style: OutlinedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                      ),
+                    ),
+                  ),
+                ],
               ),
-              const SizedBox(width: 8),
-              ElevatedButton(
-                onPressed: copyCodeToClipboard,
-                child: const Text('초대코드 복사하기'),
-              ),
-            ],
+            ),
           ),
           if (_isKakaoTalkReturned)
             Padding(
-              padding: const EdgeInsets.only(top: 8.0),
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
               child: Text(
                 '서포터가 초대를 수락해야 알람 공유 기능이 활성화 됩니다.\n올바른 상대에게 초대 링크가 전송되었는지 정확하게 확인해 주세요',
                 style: TextStyle(

--- a/lib/widgets/supporter_section.dart
+++ b/lib/widgets/supporter_section.dart
@@ -219,7 +219,7 @@ class _SupporterSectionState extends State<SupporterSection>
         if (_challengerSupporterInfo?.supporterId == null) ...[
           ElevatedButton(
             onPressed: shareLinkToSupporter,
-            child: const Text('서포터 초대하기'),
+            child: const Text('카카오톡으로 서포터 초대하기'),
           ),
           if (_isKakaoTalkReturned)
             Padding(

--- a/lib/widgets/supporter_section.dart
+++ b/lib/widgets/supporter_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
 import 'package:notiyou/entities/current_participant.dart';
 import 'package:notiyou/models/challenger_supporter_model.dart';
@@ -7,6 +8,7 @@ import 'package:notiyou/services/challenger_code/challenger_code_service.dart';
 import 'package:notiyou/services/invite_deep_link_service.dart';
 import 'package:notiyou/services/challenger_config_service.dart';
 import 'package:notiyou/services/participant_service.dart';
+import 'package:flutter/rendering.dart';
 
 class SupporterSection extends StatefulWidget {
   const SupporterSection({super.key});
@@ -211,15 +213,51 @@ class _SupporterSectionState extends State<SupporterSection>
     }
   }
 
+  Future<void> copyCodeToClipboard() async {
+    try {
+      final user = await AuthService.getUserSafe();
+      final challengerCode =
+          await ChallengerCodeServiceImpl.instance.generateCode(user.id);
+      await Clipboard.setData(ClipboardData(text: challengerCode));
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('초대코드가 클립보드에 복사되었습니다'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('초대코드 복사 중 오류가 발생했습니다'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
         const SizedBox(height: 20),
         if (_challengerSupporterInfo?.supporterId == null) ...[
-          ElevatedButton(
-            onPressed: shareLinkToSupporter,
-            child: const Text('카카오톡으로 서포터 초대하기'),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                onPressed: shareLinkToSupporter,
+                child: const Text('카카오톡으로 서포터 초대하기'),
+              ),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: copyCodeToClipboard,
+                child: const Text('초대코드 복사하기'),
+              ),
+            ],
           ),
           if (_isKakaoTalkReturned)
             Padding(


### PR DESCRIPTION
## 요약
- 서포터 초대코드를 클립보드로 복사하기 버튼 추가
- 설정 페이지 디자인 대대적 개편 by CursorAi


## 작업 내용



## 기타 사항

## 체크리스트



## 스크린샷
<img width="376" alt="스크린샷 2025-05-26 오후 8 29 43" src="https://github.com/user-attachments/assets/e6827243-b60c-4d46-b179-49b3b95eae0e" />
